### PR TITLE
Fixed KakaduDemoProcessor Memory Issue By Changing files to .bmp

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/KakaduDemoProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/KakaduDemoProcessor.java
@@ -136,9 +136,9 @@ class KakaduDemoProcessor extends AbstractJava2DProcessor implements FileProcess
      */
     private static void createStdoutSymlink() throws IOException {
         Path tempDir = Application.getTempPath();
-
+        ///changed this to .bmp as .tif was throwing std:bad_alloc errors
         final String name = KakaduDemoProcessor.class.getSimpleName() + "-" +
-                UUID.randomUUID() + ".tif";
+                UUID.randomUUID() + ".bmp";
         final Path link = tempDir.resolve(name);
         final Path devStdout = Paths.get("/dev/stdout");
 
@@ -160,7 +160,7 @@ class KakaduDemoProcessor extends AbstractJava2DProcessor implements FileProcess
      */
     private static Path getIntermediateImageFile(OperationList opList) {
         final String name = opList.toFilename() + "-" +
-                Thread.currentThread().getName() + ".tif";
+                Thread.currentThread().getName() + ".bmp";
         return getScratchDir().resolve(name);
     }
 
@@ -369,7 +369,7 @@ class KakaduDemoProcessor extends AbstractJava2DProcessor implements FileProcess
 
         try (InputStream is = Files.newInputStream(intermediateFile)) {
             final ImageReader reader =
-                    new ImageReaderFactory().newImageReader(is, Format.TIF);
+                    new ImageReaderFactory().newImageReader(is, Format.BMP);
             try {
                 final BufferedImage image = reader.read();
                 Set<ReaderHint> hints =
@@ -414,7 +414,7 @@ class KakaduDemoProcessor extends AbstractJava2DProcessor implements FileProcess
                     new StreamCopier(processErrorStream, errorOutput));
 
             final ImageReader reader = new ImageReaderFactory().newImageReader(
-                    processInputStream, Format.TIF);
+                    processInputStream, Format.BMP);
             try {
                 final BufferedImage image = reader.read();
                 Set<ReaderHint> hints =


### PR DESCRIPTION
Hello @adolski. Since we were having those issues with the KakaduNativeProcessor, outlined in issue [#303](https://github.com/cantaloupe-project/cantaloupe/issues/303), with the native processor in release/4.1  I decided to roll the version back to release/4.0 and use the KakaduDemoProcessor. I rolled the version back to this version because I know you are in the process of deprecating the demo processor in version 4.1 plus It wasn't working correctly anyways(Probably due to the deprecation). 

Once I switched and got everything set up I found another bug right away when using the demo processor. The error being thrown was 

`java.io.IOException: I/O error reading header! (command output: terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
)`
It seemed to be coming from Kakadu itself. I verified this by running this in the command line.

` ./kdu_expand -quiet -resilient -no_alpha -i /var/cache/cantaloupe/source/6a/11/c8/6a11c8a353692e0c72a388449316b3d0 -o /tmp/cantaloupe/KakaduDemoProcessor-37ace037-ffa3-4740-a5c6-4d8adaf5afc4.tif`

This threw the same error code. After combing through the Kakadu docs and online. I found that the error is thrown do to not enough memory being allocated to read/ write the file. Since tifs are large files anyways, I discovered the next best option was to convert it to a bmp. After running the tests and producing a maven build I found that everything works perfectly now. No crashes, errors, and good performance. Here are the changes to facilitate this on release/4.0

 