### PR TITLE
Added logstash configuration

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -668,9 +668,11 @@ log.application.ConsoleAppender.enabled = true
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
 log.application.FileAppender.enabled = false
 log.application.FileAppender.pathname = /path/to/logs/application.log
+log.application.FileAppender.logstash.enabled = false
 
 log.application.RollingFileAppender.enabled = false
 log.application.RollingFileAppender.pathname = /path/to/logs/application.log
+log.application.RollingFileAppender.logstash.enabled = false
 log.application.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /path/to/logs/application-%d{yyyy-MM-dd}.log
 log.application.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
@@ -692,9 +694,11 @@ log.application.SyslogAppender.facility = LOCAL0
 # N.B.: Don't enable FileAppender and RollingFileAppender simultaneously!
 log.error.FileAppender.enabled = false
 log.error.FileAppender.pathname = /path/to/logs/error.log
+log.error.FileAppender.logstash.enabled = false
 
 log.error.RollingFileAppender.enabled = false
 log.error.RollingFileAppender.pathname = /path/to/logs/error.log
+log.error.RollingFileAppender.logstash.enabled = false
 log.error.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /path/to/logs/error-%d{yyyy-MM-dd}.log
 log.error.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>logback-core</artifactId>
             <version>1.2.3</version>
         </dependency>
+        <!-- Allow the use of Logstash encoders with logback -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>6.1</version>
+        </dependency>
         <!-- Used by S3Cache and DynamoDBCache-->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,9 +27,18 @@
             <appender name="AppFileLog" class="ch.qos.logback.core.FileAppender">
                 <filter class="edu.illinois.library.cantaloupe.logging.ApplicationLogFilter" />
                 <file>${log.application.FileAppender.pathname}</file>
-                <encoder>
-                    <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-                </encoder>
+                <if condition='property("log.application.FileAppender.logstash.enabled").contains("true")'>
+                    <then>
+                        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                            <includeContext>false</includeContext>
+                        </encoder>
+                    </then>
+                    <else>
+                        <encoder>
+                            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+                        </encoder>
+                    </else>
+                </if>
             </appender>
         </then>
     </if>
@@ -39,9 +48,18 @@
             <appender name="ErrorFileLog" class="ch.qos.logback.core.FileAppender">
                 <filter class="edu.illinois.library.cantaloupe.logging.ApplicationErrorLogFilter" />
                 <file>${log.error.FileAppender.pathname}</file>
-                <encoder>
-                    <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-                </encoder>
+                <if condition='property("log.error.FileAppender.logstash.enabled").contains("true")'>
+                    <then>
+                        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                            <includeContext>false</includeContext>
+                        </encoder>
+                    </then>
+                    <else>
+                        <encoder>
+                            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+                        </encoder>
+                    </else>
+                </if>
             </appender>
         </then>
     </if>
@@ -59,9 +77,18 @@
                         </rollingPolicy>
                     </then>
                 </if>
-                <encoder>
-                    <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-                </encoder>
+                <if condition='property("log.application.RollingFileAppender.logstash.enabled").contains("true")'>
+                    <then>
+                        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                            <includeContext>false</includeContext>
+                        </encoder>
+                    </then>
+                    <else>
+                        <encoder>
+                            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+                        </encoder>
+                    </else>
+                </if>
             </appender>
         </then>
     </if>
@@ -79,9 +106,18 @@
                         </rollingPolicy>
                     </then>
                 </if>
-                <encoder>
-                    <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
-                </encoder>
+                <if condition='property("log.error.RollingFileAppender.logstash.enabled").contains("true")'>
+                    <then>
+                        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                            <includeContext>false</includeContext>
+                        </encoder>
+                    </then>
+                    <else>
+                        <encoder>
+                            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+                        </encoder>
+                    </else>
+                </if>
             </appender>
         </then>
     </if>


### PR DESCRIPTION
Just added the bare minimum for error and application logs.  Due to how access logs are created it takes a bit more to add logback-access to the project so I left that out for now.  I also opted not to enable `<includeCallerData>true</includeCallerData>` as the Logstash Logback Encoder documentation says that is a costly option to have turned on in a production environment.  It's possible to have a "debug" version of this at some time as well.

This implementation assumes a logstash shipper running on the server alongside Cantaloupe which is outside the scope of this PR.  Generally just making a JSON log file that's ready to be sent off to an ELK stack.  Obviously more configuration can be added to make this more robust but for now I felt this was the best bang with the fewest changes.