### PR TITLE
Bugfix/fix null pointer in stringoverlay

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
@@ -5,6 +5,8 @@ import edu.illinois.library.cantaloupe.image.ScaleConstraint;
 import edu.illinois.library.cantaloupe.operation.Color;
 import edu.illinois.library.cantaloupe.operation.Operation;
 import edu.illinois.library.cantaloupe.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Font;
 import java.awt.font.TextAttribute;
@@ -17,6 +19,8 @@ import java.util.Map;
  * {@link OverlayService}.</p>
  */
 public class StringOverlay extends Overlay implements Operation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StringOverlay.class);
 
     private Color backgroundColor;
     private Color color;
@@ -156,14 +160,22 @@ public class StringOverlay extends Overlay implements Operation {
     @Override
     public Map<String, Object> toMap(Dimension fullSize,
                                      ScaleConstraint scaleConstraint) {
+        Float fontWeight = TextAttribute.WEIGHT_REGULAR;
+        if (getFont().getAttributes().get(TextAttribute.WEIGHT) != null) {
+            fontWeight = (Float)getFont().getAttributes().get(TextAttribute.WEIGHT);
+        }
+        Float tracking = 0.0f;
+        if (getFont().getAttributes().get(TextAttribute.TRACKING) != null) {
+            tracking = (Float)getFont().getAttributes().get(TextAttribute.TRACKING);
+        }
         return Map.ofEntries(
                 Map.entry("background_color", getBackgroundColor().toRGBAHex()),
                 Map.entry("class", getClass().getSimpleName()),
                 Map.entry("color", getColor().toRGBAHex()),
                 Map.entry("font", getFont().getName()),
                 Map.entry("font_size", getFont().getSize()),
-                Map.entry("font_weight", getFont().getAttributes().get(TextAttribute.WEIGHT)),
-                Map.entry("glyph_spacing", getFont().getAttributes().get(TextAttribute.TRACKING)),
+                Map.entry("font_weight", fontWeight),
+                Map.entry("glyph_spacing", tracking),
                 Map.entry("inset", getInset()),
                 Map.entry("position", getPosition().toString()),
                 Map.entry("string", getString()),

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
@@ -5,8 +5,6 @@ import edu.illinois.library.cantaloupe.image.ScaleConstraint;
 import edu.illinois.library.cantaloupe.operation.Color;
 import edu.illinois.library.cantaloupe.operation.Operation;
 import edu.illinois.library.cantaloupe.util.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.awt.Font;
 import java.awt.font.TextAttribute;
@@ -19,8 +17,6 @@ import java.util.Map;
  * {@link OverlayService}.</p>
  */
 public class StringOverlay extends Overlay implements Operation {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(StringOverlay.class);
 
     private Color backgroundColor;
     private Color color;

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
@@ -18,12 +18,12 @@ public class StringOverlayTest extends BaseTest {
 
     private StringOverlay instance;
 
-    private Font newFont() {
+    private Font newFont(Float weight, Float tracking) {
         final Map<TextAttribute, Object> attributes = new HashMap<>();
         attributes.put(TextAttribute.FAMILY, "SansSerif");
         attributes.put(TextAttribute.SIZE, 12);
-        attributes.put(TextAttribute.WEIGHT, 2.0f);
-        attributes.put(TextAttribute.TRACKING, 0.1f);
+        attributes.put(TextAttribute.WEIGHT, weight);
+        attributes.put(TextAttribute.TRACKING, tracking);
         return Font.getFont(attributes);
     }
 
@@ -32,7 +32,7 @@ public class StringOverlayTest extends BaseTest {
         super.setUp();
 
         instance = new StringOverlay("cats", Position.BOTTOM_RIGHT, 5,
-                newFont(), 11, Color.BLUE, Color.ORANGE, Color.RED, 5f);
+                newFont(2.0f,  0.1f), 11, Color.BLUE, Color.ORANGE, Color.RED, 5f);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class StringOverlayTest extends BaseTest {
     void setFontThrowsExceptionWhenFrozen() {
         instance.freeze();
         assertThrows(IllegalStateException.class,
-                () -> instance.setFont(newFont()));
+                () -> instance.setFont(newFont(2.0f,  0.1f)));
     }
 
     @Test
@@ -116,6 +116,17 @@ public class StringOverlayTest extends BaseTest {
         assertEquals(instance.getStrokeColor().toRGBAHex(),
                 map.get("stroke_color"));
         assertEquals(5f, map.get("stroke_width"));
+    }
+
+    @Test
+    void toMapReturnsDefaultValueForMissingFontAttributes() {
+        Dimension fullSize = new Dimension(100, 100);
+        ScaleConstraint scaleConstraint = new ScaleConstraint(1, 1);
+        StringOverlay fontModifiedInstance = new StringOverlay("cats", Position.BOTTOM_RIGHT, 5,
+                newFont(null,  null), 11, Color.BLUE, Color.ORANGE, Color.RED, 5f);
+        Map<String,Object> map = fontModifiedInstance.toMap(fullSize, scaleConstraint);
+        assertEquals(TextAttribute.WEIGHT_REGULAR, map.get("font_weight"));
+        assertEquals(0.0f, map.get("glyph_spacing"));
     }
 
     @Test


### PR DESCRIPTION
I found that the call to `java.awt.Font.getFont()` in line 58 of `DelegateOverlayService` returns null values for many attributes even though the values are set on the `AttributeMap` being passed into the `getFont()` method call.  This pull request sets default values in the case that we are returned null values for font_weight or glyph_spacing.  I've tested this with both Oracle JDK 11 and OpenJDK 11 both with success.