### PR TITLE
Update dependencies to addres issue #331

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws-sdk.version>1.11.538</aws-sdk.version>
         <jackson.version>2.9.10</jackson.version>
+        <jackson.databind.version>2.9.10.1</jackson.databind.version>
         <jetty.version>9.4.20.v20190813</jetty.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <jruby.version>9.2.9.0</jruby.version>
         <surefire.version>3.0.0-M3</surefire.version>
     </properties>
 
@@ -348,7 +349,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <!-- Makes Jackson aware of JDK8 date/time objects -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws-sdk.version>1.11.538</aws-sdk.version>
         <jackson.version>2.9.10</jackson.version>
-        <jackson.databind.version>2.9.10.1</jackson.databind.version>
-        <jetty.version>9.4.22.v20191022</jetty.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
+        <jruby.version>9.2.7.0</jruby.version>
         <surefire.version>3.0.0-M3</surefire.version>
     </properties>
 
@@ -349,7 +348,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- Makes Jackson aware of JDK8 date/time objects -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aws-sdk.version>1.11.538</aws-sdk.version>
-        <jackson.version>2.9.9</jackson.version>
-        <jetty.version>9.4.12.v20180830</jetty.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <jackson.version>2.9.10</jackson.version>
+        <jackson.databind.version>2.9.10.1</jackson.databind.version>
+        <jetty.version>9.4.22.v20191022</jetty.version>
+        <jruby.version>9.2.9.0</jruby.version>
         <surefire.version>3.0.0-M3</surefire.version>
     </properties>
 
@@ -56,7 +57,7 @@
         <dependency>
             <groupId>biz.paluch.redis</groupId>
             <artifactId>lettuce</artifactId>
-            <version>4.3.3.Final</version>
+            <version>4.5.0.Final</version>
         </dependency>
         <!-- The application logger. -->
         <dependency>
@@ -122,7 +123,7 @@
         <dependency>
             <groupId>com.jhlabs</groupId>
             <artifactId>filters</artifactId>
-            <version>2.0.235</version>
+            <version>2.0.235-1</version>
         </dependency>
         <!-- Used by AzureStorageSource and AzureStorageCache-->
         <dependency>
@@ -167,7 +168,7 @@
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>6.0.8</version>
+            <version>6.0.11</version>
         </dependency>
         <!-- Dependency on part of Java EE that's available by default in Java 8
         but not 9 -->
@@ -238,12 +239,12 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.4.0</version>
+            <version>3.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>3.4.0</version>
+            <version>3.13.1</version>
         </dependency>
         <!-- Used for media type detection -->
         <dependency>
@@ -255,7 +256,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.64</version>
         </dependency>
         <!-- Supports <if> expressions in logback.xml -->
         <dependency>
@@ -348,7 +349,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <!-- Makes Jackson aware of JDK8 date/time objects -->
         <dependency>
@@ -595,6 +596,18 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>5.2.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+              </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
I've updated the dependencies as far as I can and still get a clean build from Travis CI.  In particular updating Jetty to the latest version does cause a build failure which is why it's only upgraded to 9.4.20