### PR TITLE
Configuration should return null if key is present but value is empty (rebased on 4.1) #333

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/config/Configuration.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/Configuration.java
@@ -2,6 +2,8 @@ package edu.illinois.library.cantaloupe.config;
 
 import edu.illinois.library.cantaloupe.util.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -238,11 +240,13 @@ public interface Configuration {
      * @return Object value corresponding to the given key, or {@literal null}
      *         if not set.
      */
-    Object getProperty(String key);
+    @Nullable
+    Object getProperty(@Nonnull String key);
 
     /**
      * @see #getString(String)
      */
+    @Nullable
     default String getString(Key key) {
         return getString(key.key());
     }
@@ -251,7 +255,8 @@ public interface Configuration {
      * @return String value corresponding to the given key, or {@literal null}
      *         if not set.
      */
-    String getString(String key);
+    @Nullable
+    String getString(@Nonnull String key);
 
     /**
      * @see #getString(String, String)

--- a/src/main/java/edu/illinois/library/cantaloupe/config/ConfigurationProvider.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/ConfigurationProvider.java
@@ -1,5 +1,7 @@
 package edu.illinois.library.cantaloupe.config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
@@ -159,8 +161,9 @@ public final class ConfigurationProvider implements Configuration {
         return defaultValue;
     }
 
+    @Nullable
     @Override
-    public Object getProperty(String key) {
+    public Object getProperty(@Nonnull String key) {
         Object value = null;
         for (Configuration config : wrappedConfigs) {
             value = config.getProperty(key);
@@ -172,7 +175,8 @@ public final class ConfigurationProvider implements Configuration {
     }
 
     @Override
-    public String getString(String key) {
+    @Nullable
+    public String getString(@Nonnull String key) {
         String value = null;
         for (Configuration config : wrappedConfigs) {
             value = config.getString(key);

--- a/src/main/java/edu/illinois/library/cantaloupe/config/EnvironmentConfiguration.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/EnvironmentConfiguration.java
@@ -4,7 +4,6 @@ import edu.illinois.library.cantaloupe.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 

--- a/src/main/java/edu/illinois/library/cantaloupe/config/EnvironmentConfiguration.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/EnvironmentConfiguration.java
@@ -2,6 +2,9 @@ package edu.illinois.library.cantaloupe.config;
 
 import edu.illinois.library.cantaloupe.util.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -134,13 +137,15 @@ class EnvironmentConfiguration implements Configuration {
         }
     }
 
+    @Nullable
     @Override
-    public Object getProperty(String key) {
+    public Object getProperty(@Nonnull String key) {
         return getString(key);
     }
 
     @Override
-    public String getString(String key) {
+    @Nullable
+    public String getString(@Nonnull String key) {
         key = toEnvironmentKey(key);
         return System.getenv(key);
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfiguration.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfiguration.java
@@ -2,6 +2,8 @@ package edu.illinois.library.cantaloupe.config;
 
 import edu.illinois.library.cantaloupe.util.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -126,7 +128,8 @@ class HeritablePropertiesConfiguration implements MultipleFileConfiguration {
         return bool;
     }
 
-    private Boolean readBoolean(String key) {
+    @Nullable
+    private Boolean readBoolean(@Nonnull String key) {
         Boolean bool = null;
         for (PropertiesDocument doc : propertiesDocs.values()) {
             if (doc.containsKey(key)) {
@@ -353,7 +356,8 @@ class HeritablePropertiesConfiguration implements MultipleFileConfiguration {
     }
 
     @Override
-    public Object getProperty(String key) {
+    @Nullable
+    public Object getProperty(@Nonnull String key) {
         return readPropertyOptimistically(key);
     }
 
@@ -373,7 +377,8 @@ class HeritablePropertiesConfiguration implements MultipleFileConfiguration {
         return prop;
     }
 
-    private Object readProperty(String key) {
+    @Nullable
+    private Object readProperty(@Nonnull String key) {
         Object prop = null;
         for (PropertiesDocument doc : propertiesDocs.values()) {
             if (doc.containsKey(key)) {
@@ -385,7 +390,8 @@ class HeritablePropertiesConfiguration implements MultipleFileConfiguration {
     }
 
     @Override
-    public String getString(String key) {
+    @Nullable
+    public String getString(@Nonnull String key) {
         return readStringOptimistically(key);
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/config/MapConfiguration.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/MapConfiguration.java
@@ -2,6 +2,8 @@ package edu.illinois.library.cantaloupe.config;
 
 import edu.illinois.library.cantaloupe.util.StringUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -126,13 +128,15 @@ public class MapConfiguration implements Configuration {
         }
     }
 
+    @Nullable
     @Override
-    public Object getProperty(String key) {
+    public Object getProperty(@Nonnull String key) {
         return configuration.get(key);
     }
 
     @Override
-    public String getString(String key) {
+    @Nullable
+    public String getString(@Nonnull String key) {
         Object value = configuration.get(key);
         if (value != null) {
             return value.toString();

--- a/src/main/java/edu/illinois/library/cantaloupe/config/PropertiesDocument.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/PropertiesDocument.java
@@ -152,8 +152,8 @@ class PropertiesDocument {
         return items.stream()
                 .filter(it -> {
                     if (it instanceof KeyValuePair) {
-                        var kvp = (KeyValuePair) it;
-                        return !kvp.value.isBlank() && key.equals(kvp.key());
+                        final KeyValuePair kvp = (KeyValuePair) it;
+                        return !kvp.value.trim().isEmpty() && key.equals(kvp.key());
                     }
                     return false;
                 })

--- a/src/main/java/edu/illinois/library/cantaloupe/config/PropertiesDocument.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/PropertiesDocument.java
@@ -1,5 +1,7 @@
 package edu.illinois.library.cantaloupe.config;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -145,10 +147,16 @@ class PropertiesDocument {
     /**
      * @return Value for the given key.
      */
-    String get(String key) {
+    @Nullable
+    String get(@Nonnull String key) {
         return items.stream()
-                .filter(it -> it instanceof KeyValuePair &&
-                        key.equals(((KeyValuePair) it).key()))
+                .filter(it -> {
+                    if (it instanceof KeyValuePair) {
+                        var kvp = (KeyValuePair) it;
+                        return !kvp.value.isBlank() && key.equals(kvp.key());
+                    }
+                    return false;
+                })
                 .findFirst()
                 .map(it -> ((KeyValuePair) it).value().trim().replaceAll("\\\\+", "\\\\"))
                 .orElse(null);

--- a/src/main/java/edu/illinois/library/cantaloupe/util/AWSClientBuilder.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/util/AWSClientBuilder.java
@@ -1,7 +1,13 @@
 package edu.illinois.library.cantaloupe.util;
 
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.*;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;

--- a/src/main/java/edu/illinois/library/cantaloupe/util/AWSClientBuilder.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/util/AWSClientBuilder.java
@@ -1,21 +1,16 @@
 package edu.illinois.library.cantaloupe.util;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
-import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.*;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Creates an AWS client using the Builder pattern.
@@ -45,10 +40,10 @@ public final class AWSClientBuilder {
      *                              configuration.
      */
     public static AWSCredentialsProvider newCredentialsProvider(
-            final String accessKeyIDFromConfig,
-            final String secretKeyFromConfig) {
+            @Nullable final String accessKeyIDFromConfig,
+            @Nullable final String secretKeyFromConfig) {
         // The provider chain will consult each provider in this list in order,
-        // and use the first one that returns something.
+        // and use the first one that returns a non-null access and secret key pair.
         final List<AWSCredentialsProvider> providers = new ArrayList<>();
         providers.add(new EnvironmentVariableCredentialsProvider());
         providers.add(new SystemPropertiesCredentialsProvider());
@@ -79,8 +74,17 @@ public final class AWSClientBuilder {
      * @param accessKeyID AWS access key ID.
      * @return The instance.
      */
-    public AWSClientBuilder accessKeyID(String accessKeyID) {
+    public AWSClientBuilder accessKeyID(@Nullable String accessKeyID) {
         this.accessKeyID = accessKeyID;
+        return this;
+    }
+
+    /**
+     * @param secretKey AWS secret key.
+     * @return The instance.
+     */
+    public AWSClientBuilder secretKey(@Nullable String secretKey) {
+        this.secretKey = secretKey;
         return this;
     }
 
@@ -102,15 +106,6 @@ public final class AWSClientBuilder {
     public AWSClientBuilder maxConnections(int maxConnections) {
         this.maxConnections = (maxConnections > 0) ?
                 maxConnections : DEFAULT_MAX_CONNECTIONS;
-        return this;
-    }
-
-    /**
-     * @param secretKey AWS secret key.
-     * @return The instance.
-     */
-    public AWSClientBuilder secretKey(String secretKey) {
-        this.secretKey = secretKey;
         return this;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/util/StringUtils.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/util/StringUtils.java
@@ -3,6 +3,7 @@ package edu.illinois.library.cantaloupe.util;
 import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -144,7 +145,11 @@ public final class StringUtils {
      * @return Boolean value of the given string.
      * @throws NumberFormatException if the string has an unrecognized format.
      */
-    public static boolean toBoolean(String str) {
+    public static boolean toBoolean(@Nullable String str) {
+        if (str == null) {
+            throw new NumberFormatException();
+        }
+
         switch (str) {
             case "1":
             case "true":

--- a/src/test/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfigurationTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfigurationTest.java
@@ -9,7 +9,8 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class HeritablePropertiesConfigurationTest extends AbstractFileConfigurationTest {
 
@@ -128,10 +129,9 @@ public class HeritablePropertiesConfigurationTest extends AbstractFileConfigurat
     }
 
     @Test
-    void testGetPropertyReturnsNullIfKeyIsSpecifiedButNoValueIsPresent() {
+    public void testGetPropertyReturnsNullIfKeyIsSpecifiedButNoValueIsPresent() throws ConfigurationException {
         instance.reload();
 
         assertNull(instance.getProperty("key_without_value"));
     }
-
 }

--- a/src/test/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfigurationTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/config/HeritablePropertiesConfigurationTest.java
@@ -55,7 +55,7 @@ public class HeritablePropertiesConfigurationTest extends AbstractFileConfigurat
             it.next();
             count++;
         }
-        assertEquals(8, count);
+        assertEquals(9, count);
     }
 
     /* getProperty(Key) */
@@ -125,6 +125,13 @@ public class HeritablePropertiesConfigurationTest extends AbstractFileConfigurat
         assertEquals("bears", docs.get(0).get("newkey"));
         assertNull(docs.get(1).get("newkey"));
         assertNull(docs.get(2).get("newkey"));
+    }
+
+    @Test
+    void testGetPropertyReturnsNullIfKeyIsSpecifiedButNoValueIsPresent() {
+        instance.reload();
+
+        assertNull(instance.getProperty("key_without_value"));
     }
 
 }

--- a/src/test/java/edu/illinois/library/cantaloupe/util/StringUtilsTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/util/StringUtilsTest.java
@@ -7,7 +7,10 @@ import org.junit.Test;
 
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class StringUtilsTest extends BaseTest {
 
@@ -106,6 +109,11 @@ public class StringUtilsTest extends BaseTest {
 
         toStrip = "longer than str";
         assertSame(str, StringUtils.stripStart(str, toStrip));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testToBooleanWithNullValueThrowsException() {
+        StringUtils.toBoolean(null);
     }
 
     @Test(expected = NumberFormatException.class)

--- a/src/test/resources/heritable_level3.properties
+++ b/src/test/resources/heritable_level3.properties
@@ -2,3 +2,4 @@ extends = heritable_level2.properties
 
 common_key = birds
 level3_key = foxes
+key_without_value =


### PR DESCRIPTION
Rebased on `4.1` 🔨 
---

Tl;DR: Fixes #333 

There are a few different ways to fix #333 but I feel like this is the root cause. Since Cantaloupe ships an `example.properties` file with keys having no value, it seemed to me that the intended configuration API was broken.

If a key exists in configuration but has no value, it now returns null, whereas before the behaviour depended on the property type (e.g., String would return `""`). This brings the behaviour in line with environment properties, etc. as is standard.