### PR TITLE
Fully consume the UUID box, even if it is bigger than the buffer size

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
@@ -310,7 +310,8 @@ public final class JPEG2000MetadataReader implements AutoCloseable {
         // A UUID box can contain any kind of data, signified by the UUID.
         // This reader supports IPTC and XMP.
         if (Arrays.equals(uuid, XMP_UUID)) {
-            byte[] data = read((int) dataLength - 16);
+            byte[] data = new byte[(int)dataLength  - 16];
+            inputStream.readFully(data,  0, (int) dataLength - 16);
             xmp = new String(data, StandardCharsets.UTF_8);
             xmp = xmp.substring(xmp.indexOf("<rdf:RDF "),
                     xmp.indexOf("</rdf:RDF>") + 10);


### PR DESCRIPTION
Fixes #355 