### PR TITLE
Use readFully instead of read for all JPEG2000MetadataReader operations

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
@@ -310,8 +310,7 @@ public final class JPEG2000MetadataReader implements AutoCloseable {
         // A UUID box can contain any kind of data, signified by the UUID.
         // This reader supports IPTC and XMP.
         if (Arrays.equals(uuid, XMP_UUID)) {
-            byte[] data = new byte[(int)dataLength  - 16];
-            inputStream.readFully(data,  0, (int) dataLength - 16);
+            byte[] data = read((int)dataLength  - 16);
             xmp = new String(data, StandardCharsets.UTF_8);
             xmp = xmp.substring(xmp.indexOf("<rdf:RDF "),
                     xmp.indexOf("</rdf:RDF>") + 10);
@@ -422,11 +421,7 @@ public final class JPEG2000MetadataReader implements AutoCloseable {
 
     private byte[] read(int length) throws IOException {
         byte[] data = new byte[length];
-        int n, offset = 0;
-        while ((n = inputStream.read(
-                data, offset, data.length - offset)) < offset) {
-            offset += n;
-        }
+        inputStream.readFully(data, 0, length);
         return data;
     }
 


### PR DESCRIPTION
It turns out the issue reported  in #355 is more pervasive than just overly large UUID boxes and some unlucky JPEG2000 files exhibit the same problem when the buffer runs out.