### PR TITLE
Check for null value before trying toString - fixes #366

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
@@ -18,7 +18,6 @@ import edu.illinois.library.cantaloupe.processor.codec.ImageWriterFacade;
 import edu.illinois.library.cantaloupe.source.StreamFactory;
 import edu.illinois.library.cantaloupe.util.Stopwatch;
 import org.apache.commons.io.IOUtils;
-import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.pdmodel.DefaultResourceCache;
 import org.apache.pdfbox.pdmodel.PDDocument;

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
@@ -18,6 +18,7 @@ import edu.illinois.library.cantaloupe.processor.codec.ImageWriterFacade;
 import edu.illinois.library.cantaloupe.source.StreamFactory;
 import edu.illinois.library.cantaloupe.util.Stopwatch;
 import org.apache.commons.io.IOUtils;
+import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.pdmodel.DefaultResourceCache;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -185,7 +186,9 @@ class PdfBoxProcessor extends AbstractProcessor
                 PDDocumentInformation info = doc.getDocumentInformation();
                 Map<String, String> pdfMetadata = new HashMap<>();
                 for (String key : info.getMetadataKeys()) {
-                    pdfMetadata.put(key, info.getCOSObject().getItem(key).toString());
+                    if (info.getPropertyStringValue(key) != null) {
+                        pdfMetadata.put(key, info.getPropertyStringValue(key).toString());
+                    }
                 }
                 metadata.setNativeMetadata(pdfMetadata);
             }

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/PdfBoxProcessor.java
@@ -185,7 +185,7 @@ class PdfBoxProcessor extends AbstractProcessor
                 PDDocumentInformation info = doc.getDocumentInformation();
                 Map<String, String> pdfMetadata = new HashMap<>();
                 for (String key : info.getMetadataKeys()) {
-                    pdfMetadata.put(key, info.getPropertyStringValue(key).toString());
+                    pdfMetadata.put(key, info.getCOSObject().getItem(key).toString());
                 }
                 metadata.setNativeMetadata(pdfMetadata);
             }


### PR DESCRIPTION
Check for null before trying to add a metadata string value to the map.