### PR TITLE
Add support for microscopy images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,13 @@
             <groupId>it.geosolutions.imageio-ext</groupId>
             <artifactId>imageio-ext-tiff</artifactId>
             <version>1.3.2</version>
+            <exclusions>
+                <!-- jai_imageio jar is already included in formats-gpl -->
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_imageio</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -406,6 +413,12 @@
             <version>3.1.1</version>
             <type>maven-plugin</type>
         </dependency>
+        <!-- Provides Bio-formats for microscopy images support -->
+        <dependency>
+            <groupId>ome</groupId>
+            <artifactId>formats-gpl</artifactId>
+            <version>6.5.0</version>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -414,6 +427,18 @@
             <id>imageio-ext-repository</id>
             <name>imageio-ext Repository</name>
             <url>https://maven.geo-solutions.it/</url>
+        </repository>
+        <!-- Provides javax.media:jai_codec -->
+        <repository>
+            <id>geotoolkit-repository</id>
+            <name>geotoolkit Repository</name>
+            <url>http://maven.geotoolkit.org/</url>
+        </repository>
+        <!-- Provides formats-gpl -->
+        <repository>
+            <id>ome</id>
+            <name>OME Artifactory</name>
+            <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
         </repository>
     </repositories>
 
@@ -607,7 +632,7 @@
                         </goals>
                     </execution>
                 </executions>
-              </plugin>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/edu/illinois/library/cantaloupe/image/Format.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/Format.java
@@ -24,7 +24,7 @@ public final class Format implements Comparable<Format> {
     }
 
     public enum Type {
-        IMAGE, UNKNOWN, VIDEO
+        IMAGE, MICROSCOPY, UNKNOWN, VIDEO
     }
 
     // N.B.: For each one of these constants, there should be a corresponding
@@ -44,6 +44,18 @@ public final class Format implements Comparable<Format> {
             false);
 
     /**
+     * Ventana BIF.
+     */
+    public static final Format BIF = new Format(
+            "bif",
+            "BIF",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("bif"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
      * Windows Bitmap image format.
      */
     public static final Format BMP = new Format(
@@ -53,6 +65,18 @@ public final class Format implements Comparable<Format> {
             List.of("image/bmp", "image/x-bmp", "image/x-ms-bmp"),
             List.of("bmp", "dib"),
             Type.IMAGE,
+            true);
+
+    /**
+     * Zeiss CZI.
+     */
+    public static final Format CZI = new Format(
+            "czi",
+            "CZI",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("czi"),
+            Type.MICROSCOPY,
             true);
 
     /**
@@ -92,6 +116,18 @@ public final class Format implements Comparable<Format> {
             true);
 
     /**
+     * Bitplane Imaris.
+     */
+    public static final Format IMS = new Format(
+            "ims",
+            "IMS",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("ims"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
      * JPEG2000 image format.
      */
     public static final Format JP2 = new Format(
@@ -114,6 +150,18 @@ public final class Format implements Comparable<Format> {
             List.of("jpg", "jpeg"),
             Type.IMAGE,
             false);
+
+    /**
+     * Keller Lab Block.
+     */
+    public static final Format KLB = new Format(
+            "klb",
+            "KLB",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("klb"),
+            Type.MICROSCOPY,
+            true);
 
     /**
      * Apple QuickTime video format.
@@ -152,6 +200,18 @@ public final class Format implements Comparable<Format> {
             false);
 
     /**
+     * Hamamatsu ndpi.
+     */
+    public static final Format NDPI = new Format(
+            "ndpi",
+            "ndpi",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("ndpi", "ndpis"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
      * Portable Document Format.
      */
     public static final Format PDF = new Format(
@@ -176,6 +236,42 @@ public final class Format implements Comparable<Format> {
             true);
 
     /**
+     * PerkinElmer Vectra QPTIFF.
+     */
+    public static final Format QPTIFF = new Format(
+            "qptiff",
+            "QPTIFF",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("qptiff"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
+     * Leica SCN.
+     */
+    public static final Format SCN = new Format(
+            "scn",
+            "SCN",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("scn"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
+     * Aperio SVS TIFF.
+     */
+    public static final Format SVS = new Format(
+            "svs",
+            "SVS",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("svs"),
+            Type.MICROSCOPY,
+            true);
+
+    /**
      * Tagged Image File Format.
      */
     public static final Format TIF = new Format(
@@ -186,6 +282,19 @@ public final class Format implements Comparable<Format> {
             List.of("tif", "ptif", "tiff"),
             Type.IMAGE,
             true);
+
+    /**
+     * cellSens VSI.
+     */
+    public static final Format VSI = new Format(
+            "VSI",
+            "vsi",
+            ImageType.RASTER,
+            List.of("application/octet-stream"),
+            List.of("vsi"),
+            Type.MICROSCOPY,
+            true);
+
 
     /**
      * WebM video format.
@@ -250,8 +359,8 @@ public final class Format implements Comparable<Format> {
     private Type type;
 
     static {
-        KNOWN_FORMATS.addAll(Set.of(AVI, BMP, DCM, FLV, GIF, JP2, JPG, MOV,
-                MP4, MPG, PDF, PNG, TIF, UNKNOWN, WEBM, WEBP, XPM));
+        KNOWN_FORMATS.addAll(Set.of(AVI, BIF, BMP, CZI, DCM, FLV, GIF, IMS, JP2, JPG, KLB, MOV,
+                MP4, MPG, NDPI, PDF, PNG, QPTIFF, SCN, SVS, TIF, VSI, UNKNOWN, WEBM, WEBP, XPM));
     }
 
     /**

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/AutomaticSelectionStrategy.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/AutomaticSelectionStrategy.java
@@ -16,6 +16,8 @@ class AutomaticSelectionStrategy implements SelectionStrategy {
     private static final List<Class<? extends Processor>> JPG_CANDIDATES = List.of(
             TurboJpegProcessor.class,
             Java2dProcessor.class);
+    private static final List<Class<? extends Processor>> MICROSCOPY_CANDIDATES = List.of(
+            MicroscopyProcessor.class);
     private static final List<Class<? extends Processor>> PDF_CANDIDATES = List.of(
             PdfBoxProcessor.class);
     private static final List<Class<? extends Processor>> VIDEO_CANDIDATES = List.of(
@@ -29,6 +31,8 @@ class AutomaticSelectionStrategy implements SelectionStrategy {
             return JP2_CANDIDATES;
         } else if (Format.JPG.equals(sourceFormat)) {
             return JPG_CANDIDATES;
+        } else if (Format.Type.MICROSCOPY.equals(sourceFormat.getType())) {
+            return MICROSCOPY_CANDIDATES;
         } else if (Format.PDF.equals(sourceFormat)) {
             return PDF_CANDIDATES;
         } else if (Format.Type.VIDEO.equals(sourceFormat.getType())) {

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/MicroscopyProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/MicroscopyProcessor.java
@@ -1,0 +1,97 @@
+package edu.illinois.library.cantaloupe.processor;
+
+import edu.illinois.library.cantaloupe.image.Format;
+import edu.illinois.library.cantaloupe.image.Info;
+import edu.illinois.library.cantaloupe.image.ScaleConstraint;
+import edu.illinois.library.cantaloupe.operation.*;
+import edu.illinois.library.cantaloupe.processor.codec.ImageReader;
+import edu.illinois.library.cantaloupe.processor.codec.ImageWriter;
+import edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactory;
+import edu.illinois.library.cantaloupe.processor.codec.ReaderHint;
+import edu.illinois.library.cantaloupe.processor.codec.microscopy.MicroscopyImageReader;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * <p>Processor using the Bio-Formats library.</p>
+ */
+public class MicroscopyProcessor extends AbstractProcessor implements FileProcessor {
+
+    private Path sourceFile;
+    private final ImageReader reader = new MicroscopyImageReader();
+
+    @Override
+    public void close() {
+        reader.dispose();
+    }
+
+    @Override
+    public void process(final OperationList ops,
+                        final Info imageInfo,
+                        final OutputStream outputStream)
+            throws FormatException, ProcessorException {
+
+        super.process(ops, imageInfo, outputStream);
+
+        final ReductionFactor rf = new ReductionFactor();
+        final Set<ReaderHint> hints = EnumSet.noneOf(ReaderHint.class);
+
+        try {
+            Crop crop = (Crop) ops.getFirst(Crop.class);
+            Scale scale = (Scale) ops.getFirst(Scale.class);
+            ScaleConstraint sc = ops.getScaleConstraint();
+
+            BufferedImage image = reader.read(crop, scale, sc, rf, hints);
+            image = Java2DPostProcessor.postProcess(image, hints, ops, imageInfo, rf);
+
+            Encode encode = (Encode) ops.getFirst(Encode.class);
+            ImageWriter writer = new ImageWriterFactory().newImageWriter(encode);
+            writer.write(image, outputStream);
+        } catch (IOException e) {
+            throw new ProcessorException(e);
+        }
+    }
+
+    @Override
+    public Set<Format> getAvailableOutputFormats() {
+        return ImageWriterFactory.supportedFormats();
+    }
+
+    @Override
+    public Info readInfo() throws IOException {
+        final Info info = new Info();
+        info.getImages().clear();
+        info.setSourceFormat(getSourceFormat());
+        info.setNumResolutions(reader.getNumResolutions());
+
+        for (int i = 0; i < reader.getNumImages(); i++) {
+            Info.Image image = new Info.Image();
+            image.setSize(reader.getSize(i));
+            image.setTileSize(reader.getTileSize(i));
+            info.getImages().add(image);
+        }
+
+        return info;
+    }
+
+    @Override
+    public Path getSourceFile() {
+        return sourceFile;
+    }
+
+    @Override
+    public void setSourceFile(Path sourceFile) {
+        this.sourceFile = sourceFile;
+        try {
+            reader.setSource(sourceFile);
+        } catch (IOException e) {
+            e.printStackTrace();
+            this.sourceFile = null;
+        }
+    }
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java
@@ -25,6 +25,7 @@ public final class ProcessorFactory {
             JaiProcessor.class,
             Java2dProcessor.class,
             KakaduNativeProcessor.class,
+            MicroscopyProcessor.class,
             OpenJpegProcessor.class,
             PdfBoxProcessor.class,
             TurboJpegProcessor.class);

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/microscopy/MicroscopyImageReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/microscopy/MicroscopyImageReader.java
@@ -195,7 +195,7 @@ public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.pr
                 // crop requested region if it exceeds image dimensions
                 // otherwise the Bio-formats reader will return an invalid tile size error
                 width = (x + width > subimageWidth) ? subimageWidth - x : width;
-                height = (y + height > subimageHeight) ? subimageWidth - y : height;
+                height = (y + height > subimageHeight) ? subimageHeight - y : height;
 
                 try {
                     if (isSingleChannelImage()) {
@@ -219,7 +219,7 @@ public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.pr
                             // channels are stored in separate planes
 
                             // check if channels colors are defined in the metadata
-                            ome.xml.model.primitives.Color testOmeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(1, 0);
+                            ome.xml.model.primitives.Color testOmeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(reader.getSeries(), 0);
                             if (testOmeColor != null) {
                                 channelsColors = new Color[reader.getSizeC()];
                             } else {
@@ -230,8 +230,7 @@ public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.pr
                                 int plane = reader.getIndex(0, c, 0);
                                 bytesChannels[c] = reader.openBytes(plane, x, y, width, height);
                                 if (channelsColors != null) {
-                                    ome.xml.model.primitives.Color omeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(plane, 0);
-                                    LOGGER.warn("{} {}", c, omeColor);
+                                    ome.xml.model.primitives.Color omeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(reader.getSeries(), c);
                                     channelsColors[c] = new Color(omeColor.getRed(), omeColor.getGreen(), omeColor.getBlue());
                                 }
                             }
@@ -239,7 +238,7 @@ public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.pr
                             // channels are stored in the same plane
 
                             // check if channels colors are defined in the metadata
-                            ome.xml.model.primitives.Color testOmeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(0, 1);
+                            ome.xml.model.primitives.Color testOmeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(reader.getSeries(), 0);
                             if (testOmeColor != null) {
                                 channelsColors = new Color[reader.getSizeC()];
                             } else {
@@ -251,7 +250,7 @@ public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.pr
                             for (int c = 0; c < reader.getRGBChannelCount(); c++) {
                                 bytesChannels[c] = ImageTools.splitChannels(bytes, c, reader.getRGBChannelCount(), FormatTools.getBytesPerPixel(pixelType), false, reader.isInterleaved());
                                 if (channelsColors != null) {
-                                    ome.xml.model.primitives.Color omeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(plane, c);
+                                    ome.xml.model.primitives.Color omeColor = ((IMetadata) reader.getMetadataStore()).getChannelColor(reader.getSeries(), c);
                                     channelsColors[c] = new Color(omeColor.getRed(), omeColor.getGreen(), omeColor.getBlue());
                                 }
                             }

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/microscopy/MicroscopyImageReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/microscopy/MicroscopyImageReader.java
@@ -1,0 +1,313 @@
+package edu.illinois.library.cantaloupe.processor.codec.microscopy;
+
+import edu.illinois.library.cantaloupe.image.*;
+import edu.illinois.library.cantaloupe.image.Dimension;
+import edu.illinois.library.cantaloupe.image.Rectangle;
+import edu.illinois.library.cantaloupe.operation.*;
+import edu.illinois.library.cantaloupe.processor.codec.BufferedImageSequence;
+import edu.illinois.library.cantaloupe.processor.codec.ReaderHint;
+import edu.illinois.library.cantaloupe.source.StreamFactory;
+import loci.formats.FormatException;
+import loci.formats.MetadataTools;
+import loci.formats.gui.BufferedImageReader;
+import loci.formats.meta.IMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.stream.ImageInputStream;
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.Set;
+
+public class MicroscopyImageReader implements edu.illinois.library.cantaloupe.processor.codec.ImageReader {
+
+    private final BufferedImageReader reader;
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(MicroscopyImageReader.class);
+    private final Color[] channels_colors = {
+            new Color(0xFF0000),
+            new Color(0x00FF00),
+            new Color(0x0000FF),
+            new Color(0xFFFF00),
+            new Color(0x00FFFF),
+            new Color(0xFF00FF),
+            new Color(0xFFAA00),
+            new Color(0x7F00FF)
+    };
+
+    public MicroscopyImageReader() {
+        reader = BufferedImageReader.makeBufferedImageReader(new loci.formats.ImageReader());
+        IMetadata omeMeta = MetadataTools.createOMEXMLMetadata();
+        reader.setMetadataStore(omeMeta);
+        reader.setFlattenedResolutions(false);
+    }
+
+    @Override
+    public boolean canSeek() {
+        return true;
+    }
+
+    @Override
+    public void dispose() {
+        try {
+            reader.close(false);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Compression getCompression(int imageIndex) {
+        return Compression.UNDEFINED;
+    }
+
+    @Override
+    public Metadata getMetadata(int imageIndex) {
+        return new Metadata();
+    }
+
+    @Override
+    public int getNumImages() {
+        return 1;
+    }
+
+    @Override
+    public int getNumResolutions() {
+        return reader.getResolutionCount();
+    }
+
+    @Override
+    public Dimension getSize(int imageIndex) {
+        final int width = reader.getSizeX();
+        final int height = reader.getSizeY();
+        return new Dimension(width, height);
+    }
+
+    @Override
+    public Dimension getTileSize(int imageIndex) {
+        final int width = reader.getOptimalTileWidth();
+        final int height = reader.getOptimalTileHeight();
+        return new Dimension(width, height);
+    }
+
+    @Override
+    public BufferedImage read() throws IOException {
+        return null;
+    }
+
+    /**
+     * <p>Override that is multi-resolution and tile-aware.</p>
+     *
+     * <p>After reading, clients should check the reader hints to see whether
+     * the returned image will require additional cropping.</p>
+     */
+    @Override
+    public BufferedImage read(Crop crop, Scale scale, ScaleConstraint scaleConstraint, ReductionFactor reductionFactor, Set<ReaderHint> hints) throws IOException {
+        if (crop == null) {
+            crop = new CropByPercent();
+        }
+        if (scale == null) {
+            scale = new ScaleByPercent();
+        }
+        BufferedImage image = readSmallestUsableSubimage(crop, scale, scaleConstraint, reductionFactor);
+        hints.add(ReaderHint.ALREADY_CROPPED);
+        return image;
+    }
+
+    @Override
+    public RenderedImage readRendered(Crop crop, Scale scale, ScaleConstraint scaleConstraint, ReductionFactor reductionFactor, Set<ReaderHint> hints) throws IOException {
+        return null;
+    }
+
+    @Override
+    public BufferedImageSequence readSequence() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void setSource(Path imageFile) throws IOException {
+        try {
+            reader.close(true);
+            reader.setId(imageFile.toString());
+        } catch (FormatException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public void setSource(ImageInputStream inputStream) throws IOException {
+        throw new IOException("Stream source not supported");
+    }
+
+    @Override
+    public void setSource(StreamFactory streamFactory) throws IOException {
+        throw new IOException("Stream source not supported");
+    }
+
+    /**
+     * Reads the smallest image that can fulfill the given crop and scale from
+     * a multi-resolution image.
+     *
+     * @param crop            Requested crop.
+     * @param scale           Requested scale.
+     * @param scaleConstraint Virtual scale constraint applied to the image.
+     * @param reductionFactor Will be set to the reduction factor of the
+     *                        returned image.
+     * @return                Smallest image fitting the requested operations.
+     */
+    private BufferedImage readSmallestUsableSubimage (
+            final Crop crop,
+            final Scale scale,
+            final ScaleConstraint scaleConstraint,
+            final ReductionFactor reductionFactor) throws IOException {
+        reader.setResolution(0);
+        final Dimension fullSize = getSize(0);
+        final Rectangle regionRect = crop.getRectangle(
+                fullSize, new ReductionFactor(), scaleConstraint);
+        BufferedImage bestImage = null;
+
+        int numResolutions = reader.getResolutionCount();
+
+        for (int i = numResolutions - 1; i >= 0; i--) {
+            reader.setResolution(i);
+            final int subimageWidth = reader.getSizeX();
+            final int subimageHeight = reader.getSizeY();
+
+            final double reducedScale =  (double) subimageWidth / fullSize.width();
+            if (fits(regionRect.size(), scale, scaleConstraint, reducedScale)) {
+                reductionFactor.factor = ReductionFactor.forScale(reducedScale).factor;
+                LOGGER.debug("Subimage {}: {}x{} - fits! " + "({}x reduction factor)",
+                        i, subimageWidth, subimageHeight,
+                        reductionFactor.factor);
+                int x = (int)(regionRect.x() * reducedScale);
+                int y = (int)(regionRect.y() * reducedScale);
+                int width = (int)(regionRect.width() * reducedScale);
+                int height = (int)(regionRect.height() * reducedScale);
+
+                // crop requested region if it exceeds image dimensions
+                // otherwise the Bio-formats reader will return an invalid tile size error
+                width = (x + width > subimageWidth) ? subimageWidth - x : width;
+                height = (y + height > subimageHeight) ? subimageWidth - y : height;
+
+                final Rectangle reducedRect = new Rectangle(x, y, width, height);
+
+                try {
+                    if (reader.getEffectiveSizeC() == 1) {
+                        // image is grayscale or RGB
+                        bestImage = reader.openImage(0, reducedRect.intX(), reducedRect.intY(), reducedRect.intWidth(), reducedRect.intHeight());
+                    } else {
+                        // image has multiple channels (e.g. fluorescence microscopy image)
+                        // assign a different color to each channel and merge them using alpha compositing
+                        if (reader.getEffectiveSizeC() > channels_colors.length) {
+                            throw new IOException(MessageFormat.format("A maximum of {0} channels is supported (image has {1} channels)", channels_colors.length, reader.getEffectiveSizeC()));
+                        }
+                        bestImage = new BufferedImage(reducedRect.intWidth(), reducedRect.intHeight(), BufferedImage.TYPE_INT_ARGB);
+                        Graphics2D g = bestImage.createGraphics();
+                        g.setBackground(Color.BLACK);
+                        g.clearRect(0,0,reducedRect.intWidth(), reducedRect.intHeight());
+                        g.setComposite(AlphaComposite.SrcAtop);
+
+                        for (int c = 0; c < reader.getEffectiveSizeC(); c++) {
+                            int plane = reader.getIndex(0, c, 0);
+                            BufferedImage image = reader.openImage(plane, reducedRect.intX(), reducedRect.intY(), reducedRect.intWidth(), reducedRect.intHeight());
+                            image = gray_to_RGBA(image, channels_colors[c]);
+                            g.drawImage(image, 0, 0, null);
+                        }
+                        g.dispose();
+                    }
+                } catch (FormatException e) {
+                    throw new IOException(e);
+                }
+                break;
+            } else {
+                LOGGER.trace("Subimage {}: {}x{} - too small",
+                        i, subimageWidth, subimageHeight);
+            }
+        }
+        reader.setResolution(0);
+        return bestImage;
+    }
+
+    /**
+     * @param regionSize      Size of a cropped source image region.
+     * @param scale           Requested scale.
+     * @param scaleConstraint Scale constraint to be applied to the requested
+     *                        scale.
+     * @param reducedScale    Reduced scale of a pyramid level.
+     * @return                Whether the given source image region can be
+     *                        satisfied by the given reduced scale at the
+     *                        requested scale.
+     */
+    private boolean fits(final Dimension regionSize,
+                         final Scale scale,
+                         final ScaleConstraint scaleConstraint,
+                         final double reducedScale) {
+        if (scale instanceof ScaleByPercent) {
+            return fits((ScaleByPercent) scale, scaleConstraint, reducedScale);
+        }
+        return fits(regionSize, (ScaleByPixels) scale, reducedScale);
+    }
+
+    private boolean fits(final ScaleByPercent scale,
+                         final ScaleConstraint scaleConstraint,
+                         final double reducedScale) {
+        final double scScale = scaleConstraint.getRational().doubleValue();
+        double cappedScale = (scale.getPercent() > 1) ? 1 : scale.getPercent();
+        return (cappedScale * scScale <= reducedScale);
+    }
+
+    private boolean fits(final Dimension regionSize,
+                         final ScaleByPixels scale,
+                         final double reducedScale) {
+        switch (scale.getMode()) {
+            case ASPECT_FIT_WIDTH:
+                double cappedWidth = (scale.getWidth() > regionSize.width()) ?
+                        regionSize.width() : scale.getWidth();
+                return (cappedWidth / regionSize.width() <= reducedScale);
+            case ASPECT_FIT_HEIGHT:
+                double cappedHeight = (scale.getHeight() > regionSize.height()) ?
+                        regionSize.height() : scale.getHeight();
+                return (cappedHeight / regionSize.height() <= reducedScale);
+            default:
+                cappedWidth = (scale.getWidth() > regionSize.width()) ?
+                        regionSize.width() : scale.getWidth();
+                cappedHeight = (scale.getHeight() > regionSize.height()) ?
+                        regionSize.height() : scale.getHeight();
+                return (cappedWidth / regionSize.width() <= reducedScale &&
+                        cappedHeight / regionSize.height() <= reducedScale);
+        }
+    }
+
+    private BufferedImage gray_to_RGBA(BufferedImage srcImage, Color color) {
+        int w = srcImage.getWidth();
+        int h = srcImage.getHeight();
+        float[] RGBA = new float[4];
+        color.getRGBComponents(RGBA);
+
+        BufferedImage destImage = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        WritableRaster srcRaster = srcImage.getRaster();
+        WritableRaster destRaster = destImage.getRaster();
+        int[] srcSamples = new int[w*h];
+        int[][] destSamples = new int[4][w*h];
+        srcRaster.getSamples(0,0,w, h, 0, srcSamples);
+
+        for (int i=0; i<srcSamples.length; i++) {
+            int gray = srcSamples[i];
+            for (int c=0; c<4; c++) {
+                destSamples[c][i] = (int)(gray*RGBA[c]);
+            }
+        }
+        for (int c=0; c<4; c++) {
+            destRaster.setSamples(0,0,w,h, c, destSamples[c]);
+        }
+        return destImage;
+    }
+}


### PR DESCRIPTION
This pull request adds support for microscopy images using the Bio-formats library.
The new classes `MicroscopyProcessor` and `MicroscopyImageReader` are implemented and the new `Format.Type` `MICROSCOPY` is defined.

### Supported formats
Bio-formats supports several image formats (see the list [here](https://docs.openmicroscopy.org/bio-formats/6.5.0/supported-formats.html)).
For now a `Format`  has been defined for the following pyramidal image formats

- Ventana BIF
- Zeiss CZI
- Bitplane Imaris
- Keller Lab Block
- Hamamatsu ndpi
- PerkinElmer Vectra QPTIFF
- Leica SCN
- Aperio SVS TIFF
- cellSens VSI

OME-TIFF images are also supported, but only using `ManualSelectionStrategy`. Beacuse they are TIFF files there is no way to detect them with `AutomaticSelectionStrategy`.
