### PR TITLE
Bugfix for error when delegate requests nil overlay

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -250,7 +250,12 @@ public final class OperationList implements Iterable<Operation> {
             if (service.isEnabled() &&
                     service.shouldApplyToImage(getResultingSize(sourceImageSize))) {
                 final Overlay overlay = service.newOverlay(delegateProxy);
-                addBefore(overlay, Encode.class);
+                if (overlay != null) {
+                    addBefore(overlay, Encode.class);
+                } else {
+                    LOGGER.trace("applyNonEndpointMutations(): delegate " +
+                            "requested no overlay.");
+                }
             } else {
                 LOGGER.trace("applyNonEndpointMutations(): overlays are " +
                         "disabled; skipping.");

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -110,6 +110,9 @@ public final class OperationList implements Iterable<Operation> {
     public void addAfter(Operation op,
                          Class<? extends Operation> afterClass) {
         checkFrozen();
+        if (op == null) {
+            return;
+        }
         final int index = lastIndexOf(afterClass);
         if (index >= 0) {
             operations.add(index + 1, op);
@@ -131,6 +134,9 @@ public final class OperationList implements Iterable<Operation> {
     public void addBefore(Operation op,
                           Class<? extends Operation> beforeClass) {
         checkFrozen();
+        if (op == null) {
+            return;
+        }
         int index = firstIndexOf(beforeClass);
         if (index >= 0) {
             operations.add(index, op);

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
@@ -66,6 +66,15 @@ public class OperationListTest extends BaseTest {
     }
 
     @Test
+    public void addWithNull() {
+        instance = new OperationList();
+        assertFalse(instance.iterator().hasNext());
+
+        instance.add(null);
+        assertFalse(instance.iterator().hasNext());
+    }
+
+    @Test
     public void addAfterWithExistingClass() {
         instance = new OperationList(new Rotate());
         instance.addAfter(new Scale(), Rotate.class);
@@ -106,6 +115,15 @@ public class OperationListTest extends BaseTest {
     }
 
     @Test
+    public void addAfterWithNull() {
+        instance = new OperationList();
+        assertFalse(instance.iterator().hasNext());
+
+        instance.addAfter(null, Crop.class);
+        assertFalse(instance.iterator().hasNext());
+    }
+
+    @Test
     public void addBeforeWithExistingClass() {
         instance = new OperationList();
         instance.add(new Rotate());
@@ -138,6 +156,15 @@ public class OperationListTest extends BaseTest {
         instance = new OperationList();
         instance.freeze();
         instance.addBefore(new Rotate(), Crop.class);
+    }
+
+    @Test
+    public void addBeforeWithNull() {
+        instance = new OperationList();
+        assertFalse(instance.iterator().hasNext());
+
+        instance.addAfter(null, Crop.class);
+        assertFalse(instance.iterator().hasNext());
     }
 
     @Test


### PR DESCRIPTION
Hello, 

A new user here - and very much enjoying Cantaloupe so far. Thank you!

I'm not sure how much you welcome patches, but I've been using the latest 4.1 release and had problems when attempting to control an overlay with a delegate method. The docs indicate that to disable an overlay, the delegate method should return `nil`, however when I tried this, I got a nasty stack trace from within `OperationList` about a null operation.

The fix is to guard against null, but I wasn't sure where in the call stack to fix it, and not being familiar with the code base, I'm not sure what your local styles are. But I noticed two things:

1) that the `OperationList.add()` method already had a non-null check, so I thought adding them to `addAfter` and `addBefore` would be useful. This PR has a commit to do that.

2) it felt like the specific case should be guarded too (although I wasn't sure about this)  and I've added another commit for that.

Hope it's helpful.

Thanks,

Charles