### PR TITLE
Fix scale constraints checking

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -785,7 +785,6 @@ public final class OperationList implements Iterable<Operation> {
             }
         }
 
-        System.out.println("----");
         // Ensure that the resulting pixel area is positive.
         if (resultingSize.isEmpty()) {
             throw new ValidationException("Resulting pixel area is empty.");

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -776,14 +776,16 @@ public final class OperationList implements Iterable<Operation> {
             }
             final double delta = Math.max(1 / fullSize.width(), 1 / fullSize.height());
             final double[] scales = scale.getResultingScales(fullSize, scaleConstraint);
+
             if (Arrays.stream(scales)
-                    .filter(s -> Math.abs(s - scaleConstraint.getRational().doubleValue()) > delta)
+                    .filter(s -> s - delta > scaleConstraint.getRational().doubleValue())
                     .findAny()
                     .isPresent()) {
                 throw new IllegalScaleException();
             }
         }
 
+        System.out.println("----");
         // Ensure that the resulting pixel area is positive.
         if (resultingSize.isEmpty()) {
             throw new ValidationException("Resulting pixel area is empty.");

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
@@ -949,6 +949,40 @@ class OperationListTest extends BaseTest {
     }
 
     @Test
+    void validateWithAllowedSmallerScale() throws Exception {
+        Dimension fullSize = new Dimension(2000, 1000);
+        Identifier identifier = new Identifier("cats");
+        OperationList ops = OperationList.builder()
+                .withIdentifier(identifier)
+                .withMetaIdentifier(MetaIdentifier.builder()
+                        .withIdentifier(identifier)
+                        .withScaleConstraint(1, 2)
+                        .build())
+                .withOperations(
+                        new ScaleByPixels(100, 50, ScaleByPixels.Mode.NON_ASPECT_FILL),
+                        new Encode(Format.get("png")))
+                .build();
+        ops.validate(fullSize, Format.get("png"));
+    }
+
+    @Test
+    void validateWithMaxAllowedScale() throws Exception {
+        Dimension fullSize = new Dimension(2000, 1000);
+        Identifier identifier = new Identifier("cats");
+        OperationList ops = OperationList.builder()
+                .withIdentifier(identifier)
+                .withMetaIdentifier(MetaIdentifier.builder()
+                        .withIdentifier(identifier)
+                        .withScaleConstraint(1, 2)
+                        .build())
+                .withOperations(
+                        new ScaleByPixels(1000, 500, ScaleByPixels.Mode.NON_ASPECT_FILL),
+                        new Encode(Format.get("png")))
+                .build();
+        ops.validate(fullSize, Format.get("png"));
+    }
+
+    @Test
     void validateWithScaleGreaterThanMaxAllowedBy1Pixel() throws Exception {
         Dimension fullSize = new Dimension(639, 343);
         Identifier identifier = new Identifier("cats");
@@ -960,23 +994,6 @@ class OperationListTest extends BaseTest {
                         .build())
                 .withOperations(
                         new ScaleByPixels(320, 172, ScaleByPixels.Mode.NON_ASPECT_FILL),
-                        new Encode(Format.get("png")))
-                .build();
-        ops.validate(fullSize, Format.get("png"));
-    }
-
-    @Test
-    void validateWithAllowedScale() throws Exception {
-        Dimension fullSize = new Dimension(1000, 1000);
-        Identifier identifier = new Identifier("cats");
-        OperationList ops = OperationList.builder()
-                .withIdentifier(identifier)
-                .withMetaIdentifier(MetaIdentifier.builder()
-                        .withIdentifier(identifier)
-                        .withScaleConstraint(1, 2)
-                        .build())
-                .withOperations(
-                        new ScaleByPixels(100, 100, ScaleByPixels.Mode.NON_ASPECT_FILL),
                         new Encode(Format.get("png")))
                 .build();
         ops.validate(fullSize, Format.get("png"));

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
@@ -966,6 +966,23 @@ class OperationListTest extends BaseTest {
     }
 
     @Test
+    void validateWithAllowedScale() throws Exception {
+        Dimension fullSize = new Dimension(1000, 1000);
+        Identifier identifier = new Identifier("cats");
+        OperationList ops = OperationList.builder()
+                .withIdentifier(identifier)
+                .withMetaIdentifier(MetaIdentifier.builder()
+                        .withIdentifier(identifier)
+                        .withScaleConstraint(1, 2)
+                        .build())
+                .withOperations(
+                        new ScaleByPixels(100, 100, ScaleByPixels.Mode.NON_ASPECT_FILL),
+                        new Encode(Format.get("png")))
+                .build();
+        ops.validate(fullSize, Format.get("png"));
+    }
+
+    @Test
     void validateWithScaleGreaterThanMaxAllowedBy2Pixels() {
         Dimension fullSize = new Dimension(639, 343);
         Identifier identifier = new Identifier("cats");


### PR DESCRIPTION
@adolski I think commit 975c3171976d3c81fd865268fe16510d20032c19 in #418 is breaking scale constraints in the allowed range in the develop branch. As soon as the effective scale s is smaller than the scale constraint minus delta, the exception is triggered. I attached a test which should run fine (s = 0.1), but throws IllegalScale Access denied.

Added two tests and tried to fix this in the expression. Please have a look at it - I'm not completely sure it handles all cases (although all tests run through now). E.g. I don't know if it's possible to specify negative scale constraints in the url (then it would need the Math.abs)