### PR TITLE
grok: upgrade to version v7.6.5

### DIFF
--- a/docker/Linux-GraalVM20/Dockerfile
+++ b/docker/Linux-GraalVM20/Dockerfile
@@ -12,6 +12,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		maven \
 		wget \
 		libopenjp2-tools \
+                liblcms2-dev \
+                libpng-dev \
+                libzstd-dev \
+                libtiff-dev \
+                libjpeg-dev \
+                zlib1g-dev \
+                libwebp-dev \
+                libimage-exiftool-perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install TurboJpegProcessor dependencies
@@ -22,10 +30,10 @@ COPY docker/Linux-JDK11/image_files/libjpeg-turbo/lib64 /opt/libjpeg-turbo/lib
 COPY dist/deps/Linux-x86-64/lib/* /usr/lib/
 
 # Install GrokProcessor dependencies
-RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/libgrokj2k1_7.6.1-1_amd64.deb \
-    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/grokj2k-tools_7.6.1-1_amd64.deb \
-    && dpkg -i ./libgrokj2k1_7.6.1-1_amd64.deb \
-    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.1-1_amd64.deb
+RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/libgrokj2k1_7.6.5-1_amd64.deb \
+    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/grokj2k-tools_7.6.5-1_amd64.deb \
+    && dpkg -i ./libgrokj2k1_7.6.5-1_amd64.deb \
+    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.5-1_amd64.deb
 
 # Install GraalVM
 RUN wget -q https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-linux-amd64-20.3.0.tar.gz \

--- a/docker/Linux-JDK11/Dockerfile
+++ b/docker/Linux-JDK11/Dockerfile
@@ -10,6 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		maven \
 		wget \
   		libopenjp2-tools \
+                liblcms2-dev \
+                libpng-dev \
+                libzstd-dev \
+                libtiff-dev \
+                libjpeg-dev \
+                zlib1g-dev \
+                libwebp-dev \
+                libimage-exiftool-perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install TurboJpegProcessor dependencies
@@ -20,10 +28,10 @@ COPY docker/Linux-JDK11/image_files/libjpeg-turbo/lib64 /opt/libjpeg-turbo/lib
 COPY dist/deps/Linux-x86-64/lib/* /usr/lib/
 
 # Install GrokProcessor dependencies
-RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/libgrokj2k1_7.6.1-1_amd64.deb \
-    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/grokj2k-tools_7.6.1-1_amd64.deb \
-    && dpkg -i ./libgrokj2k1_7.6.1-1_amd64.deb \
-    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.1-1_amd64.deb
+RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/libgrokj2k1_7.6.5-1_amd64.deb \
+    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/grokj2k-tools_7.6.5-1_amd64.deb \
+    && dpkg -i ./libgrokj2k1_7.6.5-1_amd64.deb \
+    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.5-1_amd64.deb
 
 # A non-root user is needed for some FilesystemSourceTest tests to work.
 ARG user=cantaloupe

--- a/docker/Linux-JDK15/Dockerfile
+++ b/docker/Linux-JDK15/Dockerfile
@@ -10,6 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		maven \
 		wget \
   		libopenjp2-tools \
+                liblcms2-dev \
+                libpng-dev \
+                libzstd-dev \
+                libtiff-dev \
+                libjpeg-dev \
+                zlib1g-dev \
+                libwebp-dev \
+                libimage-exiftool-perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install TurboJpegProcessor dependencies
@@ -20,10 +28,10 @@ COPY docker/Linux-JDK11/image_files/libjpeg-turbo/lib64 /opt/libjpeg-turbo/lib
 COPY dist/deps/Linux-x86-64/lib/* /usr/lib/
 
 # Install GrokProcessor dependencies
-RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/libgrokj2k1_7.6.1-1_amd64.deb \
-    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.1/grokj2k-tools_7.6.1-1_amd64.deb \
-    && dpkg -i ./libgrokj2k1_7.6.1-1_amd64.deb \
-    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.1-1_amd64.deb
+RUN wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/libgrokj2k1_7.6.5-1_amd64.deb \
+    && wget -q https://github.com/GrokImageCompression/grok/releases/download/v7.6.5/grokj2k-tools_7.6.5-1_amd64.deb \
+    && dpkg -i ./libgrokj2k1_7.6.5-1_amd64.deb \
+    && dpkg -i --ignore-depends=libjpeg62-turbo ./grokj2k-tools_7.6.5-1_amd64.deb
 
 # Install OpenJDK
 RUN wget -q https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15.0.1%2B9/OpenJDK15U-jdk_x64_linux_hotspot_15.0.1_9.tar.gz \


### PR DESCRIPTION
7.6.5 fixes a number of security bugs and crashes relative to 7.6.1