### PR TITLE
Add option to disable HEAD request

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -167,6 +167,10 @@ FilesystemSource.BasicLookupStrategy.path_suffix =
 # Trusts insecure certificates and cipher suites.
 HttpSource.allow_insecure = false
 
+# Use GET request with header Range = bytes=0-0 instead of
+# HEAD request. Useful if using Cantaloupe with presigned S3 URLs.
+HttpSource.disable_head_request = false
+
 # Request timeout in seconds.
 HttpSource.request_timeout =
 

--- a/src/main/java/edu/illinois/library/cantaloupe/config/Key.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/Key.java
@@ -109,6 +109,7 @@ public enum Key {
     HTTPSOURCE_CHUNK_CACHE_MAX_SIZE("HttpSource.chunking.cache.max_size"),
     HTTPSOURCE_LOOKUP_STRATEGY("HttpSource.lookup_strategy"),
     HTTPSOURCE_REQUEST_TIMEOUT("HttpSource.request_timeout"),
+    HTTPSOURCE_DISABLE_HEAD_REQUEST("HttpSource.disable_head_request"),
     HTTPSOURCE_URL_PREFIX("HttpSource.BasicLookupStrategy.url_prefix"),
     HTTPSOURCE_URL_SUFFIX("HttpSource.BasicLookupStrategy.url_suffix"),
     HTTPS_ENABLED("https.enabled"),

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -1688,6 +1688,26 @@
                                         </tr>
                                         <tr>
                                             <td>
+                                                <a tabindex="0" class="btn btn-sm cl-help"
+                                                   role="button" data-toggle="popover"
+                                                   data-trigger="focus"
+                                                   data-content="Use GET request with Range header instead of HEAD request.
+                                                   Useful if using Cantaloupe with presigned S3 URLs.">?</a>
+                                            </td>
+                                            <td>
+                                                <div class="checkbox">
+                                                    <label>
+                                                        <input type="checkbox"
+                                                               name="HttpSource.disable_head_request"
+                                                               value="true"
+                                                               data-requires-restart="false">
+                                                        Disable HEAD requests
+                                                    </label>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
                                                 Request Timeout
                                                 <a tabindex="0" class="btn btn-sm cl-help"
                                                    role="button" data-toggle="popover"


### PR DESCRIPTION
This PR adds option to disable HEAD request, so Cantaloupe can fetch images from S3 presigned URLs, which allows only GET requests and return 403 Forbidden for any HEAD request.

Fixes #465