### PR TITLE
Allow delegate system to produce valid HTTP 401 info.json responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 5.0.6
 
+* IIIF information endpoints return JSON in HTTP 401 responses.
 * Fixed a bug whereby the values of the `operations` and `page_count` keys
   in the delegate context were not set.
 * TurboJpegProcessor is able to generate non-JPEG derivative images, which

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## 5.0.6
 
-* IIIF information endpoints always return JSON in HTTP 4xx responses.
 * Fixed a bug whereby the values of the `operations` and `page_count` keys
   in the delegate context were not set.
 * TurboJpegProcessor is able to generate non-JPEG derivative images, which

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
@@ -364,6 +364,9 @@ public abstract class AbstractResource {
             if (code == 401) {
                 getResponse().setHeader("WWW-Authenticate",
                         info.getChallengeValue());
+                if (getRequestContext().getLocalURI().getPath().endsWith("info.json")) {
+                    return true;
+                }
             }
             throw new ResourceException(new Status(code));
         }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
@@ -1,9 +1,7 @@
 package edu.illinois.library.cantaloupe.resource.iiif.v1;
 
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import edu.illinois.library.cantaloupe.http.Method;
@@ -54,7 +52,16 @@ public class InformationResource extends IIIF1Resource {
         class CustomCallback implements InformationRequestHandler.Callback {
             @Override
             public boolean authorize() throws Exception {
-                return InformationResource.this.preAuthorize();
+                try {
+                    // The logic here is somewhat convoluted. See the method
+                    // documentation for more information.
+                    return InformationResource.this.preAuthorize();
+                } catch (ResourceException e) {
+                    if (e.getStatus().getCode() > 400) {
+                        throw e;
+                    }
+                }
+                return false;
             }
             @Override
             public void knowAvailableOutputFormats(Set<Format> formats) {
@@ -70,25 +77,18 @@ public class InformationResource extends IIIF1Resource {
                 .withRequestContext(getRequestContext())
                 .withCallback(new CustomCallback())
                 .build()) {
-            try {
-                Info info = handler.handle();
-                ImageInfo iiifInfo = new ImageInfoFactory().newImageInfo(
-                        getImageURI(),
-                        availableOutputFormats,
-                        info,
-                        getPageIndex(),
-                        getMetaIdentifier().getScaleConstraint());
-                addHeaders(iiifInfo);
-                new JacksonRepresentation(iiifInfo)
-                        .write(getResponse().getOutputStream());
-            } catch (ResourceException e) {
-                if (e.getStatus().getCode() < 500) {
-                    newHTTP4xxRepresentation(e.getStatus(), e.getMessage())
-                            .write(getResponse().getOutputStream());
-                } else {
-                    throw e;
-                }
-            }
+            Info info = handler.handle();
+
+            ImageInfo iiifInfo = new ImageInfoFactory().newImageInfo(
+                    getImageURI(),
+                    availableOutputFormats,
+                    info,
+                    getPageIndex(),
+                    getMetaIdentifier().getScaleConstraint());
+
+            addHeaders(iiifInfo);
+            new JacksonRepresentation(iiifInfo)
+                    .write(getResponse().getOutputStream());
         }
     }
 
@@ -120,16 +120,6 @@ public class InformationResource extends IIIF1Resource {
             mediaType = "application/json";
         }
         return mediaType + ";charset=UTF-8";
-    }
-
-    private JacksonRepresentation newHTTP4xxRepresentation(Status status,
-                                                           String message) {
-        final Map<String, Object> map = new LinkedHashMap<>(); // preserves key order
-        map.put("@context", "http://library.stanford.edu/iiif/image-api/1.1/context.json");
-        map.put("@id", getImageURI());
-        map.put("status", status.getCode());
-        map.put("message", message);
-        return new JacksonRepresentation(map);
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
@@ -1,9 +1,7 @@
 package edu.illinois.library.cantaloupe.resource.iiif.v2;
 
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import edu.illinois.library.cantaloupe.http.Method;
@@ -17,8 +15,6 @@ import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.script.ScriptException;
 
 /**
  * Handles IIIF Image API 2.x information requests.
@@ -61,7 +57,16 @@ public class InformationResource extends IIIF2Resource {
         class CustomCallback implements InformationRequestHandler.Callback {
             @Override
             public boolean authorize() throws Exception {
-                return InformationResource.this.preAuthorize();
+                try {
+                    // The logic here is somewhat convoluted. See the method
+                    // documentation for more information.
+                    return InformationResource.this.preAuthorize();
+                } catch (ResourceException e) {
+                    if (e.getStatus().getCode() > 400) {
+                        throw e;
+                    }
+                }
+                return false;
             }
             @Override
             public void knowAvailableOutputFormats(Set<Format> formats) {
@@ -77,19 +82,10 @@ public class InformationResource extends IIIF2Resource {
                 .withRequestContext(getRequestContext())
                 .withCallback(new CustomCallback())
                 .build()) {
+            Info info = handler.handle();
             addHeaders();
-            try {
-                Info info = handler.handle();
-                newRepresentation(info, availableOutputFormats)
-                        .write(getResponse().getOutputStream());
-            } catch (ResourceException e) {
-                if (e.getStatus().getCode() < 500) {
-                    newHTTP4xxRepresentation(e.getStatus(), e.getMessage())
-                            .write(getResponse().getOutputStream());
-                } else {
-                    throw e;
-                }
-            }
+            newRepresentation(info, availableOutputFormats)
+                    .write(getResponse().getOutputStream());
         }
     }
 
@@ -133,19 +129,6 @@ public class InformationResource extends IIIF2Resource {
                 getPageIndex(),
                 getMetaIdentifier().getScaleConstraint());
         return new JacksonRepresentation(imageInfo);
-    }
-
-    private JacksonRepresentation newHTTP4xxRepresentation(
-            Status status,
-            String message) throws ScriptException {
-        final Map<String,Object> map = new LinkedHashMap<>(); // preserves key order
-        map.put("@context", "http://iiif.io/api/image/2/context.json");
-        map.put("@id", getImageURI());
-        map.put("protocol", "http://iiif.io/api/image");
-        map.put("status", status.getCode());
-        map.put("message", message);
-        map.putAll(getDelegateProxy().getExtraIIIF2InformationResponseKeys());
-        return new JacksonRepresentation(map);
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
@@ -1,9 +1,7 @@
 package edu.illinois.library.cantaloupe.resource.iiif.v3;
 
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import edu.illinois.library.cantaloupe.http.Method;
@@ -17,8 +15,6 @@ import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.script.ScriptException;
 
 /**
  * Handles IIIF Image API 3.x information requests.
@@ -61,7 +57,16 @@ public class InformationResource extends IIIF3Resource {
         class CustomCallback implements InformationRequestHandler.Callback {
             @Override
             public boolean authorize() throws Exception {
-                return InformationResource.this.preAuthorize();
+                try {
+                    // The logic here is somewhat convoluted. See the method
+                    // documentation for more information.
+                    return InformationResource.this.preAuthorize();
+                } catch (ResourceException e) {
+                    if (e.getStatus().getCode() > 400) {
+                        throw e;
+                    }
+                }
+                return false;
             }
             @Override
             public void knowAvailableOutputFormats(Set<Format> formats) {
@@ -77,19 +82,10 @@ public class InformationResource extends IIIF3Resource {
                 .withRequestContext(getRequestContext())
                 .withCallback(new CustomCallback())
                 .build()) {
+            Info info = handler.handle();
             addHeaders();
-            try {
-                Info info = handler.handle();
-                newRepresentation(info, availableOutputFormats)
-                        .write(getResponse().getOutputStream());
-            } catch (ResourceException e) {
-                if (e.getStatus().getCode() < 500) {
-                    newHTTP4xxRepresentation(e.getStatus(), e.getMessage())
-                            .write(getResponse().getOutputStream());
-                } else {
-                    throw e;
-                }
-            }
+            newRepresentation(info, availableOutputFormats)
+                    .write(getResponse().getOutputStream());
         }
     }
 
@@ -135,21 +131,6 @@ public class InformationResource extends IIIF3Resource {
                 getPageIndex(),
                 getMetaIdentifier().getScaleConstraint());
         return new JacksonRepresentation(imageInfo);
-    }
-
-    private JacksonRepresentation newHTTP4xxRepresentation(
-            Status status,
-            String message) throws ScriptException {
-        final Map<String,Object> map = new LinkedHashMap<>(); // preserves key order
-        map.put("@context", "http://iiif.io/api/image/3/context.json");
-        map.put("id", getImageURI());
-        map.put("type", "ImageService3");
-        map.put("protocol", "http://iiif.io/api/image");
-        map.put("profile", "level2");
-        map.put("status", status.getCode());
-        map.put("message", message);
-        map.putAll(getDelegateProxy().getExtraIIIF3InformationResponseKeys());
-        return new JacksonRepresentation(map);
     }
 
 }

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageAPIResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageAPIResourceTester.java
@@ -51,6 +51,20 @@ public class ImageAPIResourceTester {
         assertStatus(200, uri);
     }
 
+    public void testAuthorizationWhenUnauthorized(URI uri) {
+        // This may vary depending on the return value of a delegate method,
+        // but the way the tests are set up, it's 401.
+        assertStatus(401, uri);
+        assertRepresentationContains("401 Unauthorized", uri);
+    }
+
+    public void testAuthorizationWhenForbidden(URI uri) {
+        // This may vary depending on the return value of a delegate method,
+        // but the way the tests are set up, it's 403.
+        assertStatus(403, uri);
+        assertRepresentationContains("403 Forbidden", uri);
+    }
+
     public void testAuthorizationWhenNotAuthorizedWhenAccessingCachedResource(URI uri)
             throws Exception {
         initializeFilesystemCache();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageAPIResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageAPIResourceTester.java
@@ -51,7 +51,7 @@ public class ImageAPIResourceTester {
         assertStatus(200, uri);
     }
 
-    public void testAuthorizationWhenUnauthorized(URI uri) {
+    public void testAuthorizationWhenUnauthorized(URI uri, String endpointPath) {
         // This may vary depending on the return value of a delegate method,
         // but the way the tests are set up, it's 401.
         assertStatus(401, uri);

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ImageResourceTester.java
@@ -30,20 +30,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ImageResourceTester extends ImageAPIResourceTester {
 
-    public void testAuthorizationWhenUnauthorized(URI uri) {
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 403.
-        assertStatus(401, uri);
-        assertRepresentationContains("401 Unauthorized", uri);
-    }
-
-    public void testAuthorizationWhenForbidden(URI uri) {
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 403.
-        assertStatus(403, uri);
-        assertRepresentationContains("403 Forbidden", uri);
-    }
-
     public void testAuthorizationWhenRedirecting(URI uri)
             throws Exception {
         Client client = newClient(uri);

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
@@ -10,6 +10,7 @@ import edu.illinois.library.cantaloupe.http.ResourceException;
 import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.resource.AbstractResource;
+import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.test.TestUtil;
 
 import java.io.File;
@@ -26,6 +27,20 @@ import static org.junit.jupiter.api.Assertions.*;
  * endpoints.
  */
 public class InformationResourceTester extends ImageAPIResourceTester {
+
+    @Override
+    public void testAuthorizationWhenUnauthorized(URI uri, String endpointPath) {
+        final String requiredJsonLdContent;
+
+        if (endpointPath.equals(Route.IIIF_1_PATH)) {
+            requiredJsonLdContent = "\"@context\":\"http://library.stanford.edu/iiif/image-api/1.1/context.json\"";
+        } else {
+            requiredJsonLdContent = "\"protocol\":\"http://iiif.io/api/image\"";
+        }
+
+        assertStatus(401, uri);
+        assertRepresentationContains(requiredJsonLdContent, uri);
+    }
 
     public void testCacheWithDerivativeCacheEnabledAndInfoCacheEnabledAndResolveFirstEnabled(
             URI uri, Path sourceFile) throws Exception {

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
@@ -27,13 +27,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class InformationResourceTester extends ImageAPIResourceTester {
 
-    public void testAuthorizationWhenForbidden(URI uri) {
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 401.
-        assertStatus(403, uri);
-        assertRepresentationContains("\"status\":403", uri);
-    }
-
     public void testCacheWithDerivativeCacheEnabledAndInfoCacheEnabledAndResolveFirstEnabled(
             URI uri, Path sourceFile) throws Exception {
         final Path cacheDir = initializeFilesystemCache();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResourceTest.java
@@ -47,7 +47,7 @@ public class ImageResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/full/full/0/color.jpg");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
@@ -51,7 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
@@ -51,15 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 401.
-        assertStatus(401, uri);
-        assertRepresentationEquals(
-                "{\"@context\":\"http://library.stanford.edu/iiif/image-api/1.1/context.json\","+
-                "\"@id\":\"" + uri.toString().replace("/info.json", "") + "\"," +
-                "\"status\":401," +
-                "\"message\":\"Unauthorized\"" +
-                "}", uri);
+        tester.testAuthorizationWhenUnauthorized(uri);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResourceTest.java
@@ -47,7 +47,7 @@ public class ImageResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/full/full/0/color.jpg");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
@@ -51,7 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
@@ -51,22 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 401.
-        assertStatus(401, uri);
-        assertRepresentationEquals("{\"@context\":\"http://iiif.io/api/image/2/context.json\","+
-                "\"@id\":\"" + uri.toString().replace("/info.json", "") + "\"," +
-                "\"protocol\":\"http://iiif.io/api/image\"," +
-                "\"status\":401," +
-                "\"message\":\"Unauthorized\"," +
-                "\"attribution\":\"Copyright My Great Organization. All rights reserved.\"," +
-                "\"license\":\"http://example.org/license.html\"," +
-                "\"service\":{" +
-                    "\"@context\":\"http://iiif.io/api/annex/services/physdim/1/context.json\"," +
-                    "\"profile\":\"http://iiif.io/api/annex/services/physdim\"," +
-                    "\"physicalScale\":0.0025," +
-                    "\"physicalUnits\":\"in\"}" +
-                "}", uri);
+        tester.testAuthorizationWhenUnauthorized(uri);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
@@ -45,7 +45,7 @@ public class ImageResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/full/max/0/color.jpg");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
@@ -51,7 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        tester.testAuthorizationWhenUnauthorized(uri);
+        tester.testAuthorizationWhenUnauthorized(uri, getEndpointPath());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
@@ -51,24 +51,7 @@ public class InformationResourceTest extends ResourceTest {
     @Test
     void testGETAuthorizationWhenUnauthorized() {
         URI uri = getHTTPURI("/unauthorized.jpg/info.json");
-        // This may vary depending on the return value of a delegate method,
-        // but the test delegate script returns 401.
-        assertStatus(401, uri);
-        assertRepresentationEquals("{\"@context\":\"http://iiif.io/api/image/3/context.json\","+
-                "\"id\":\"" + uri.toString().replace("/info.json", "") + "\"," +
-                "\"type\":\"ImageService3\"," +
-                "\"protocol\":\"http://iiif.io/api/image\"," +
-                "\"profile\":\"level2\"," +
-                "\"status\":401," +
-                "\"message\":\"Unauthorized\"," +
-                "\"attribution\":\"Copyright My Great Organization. All rights reserved.\"," +
-                "\"license\":\"http://example.org/license.html\"," +
-                "\"service\":{" +
-                    "\"@context\":\"http://iiif.io/api/annex/services/physdim/1/context.json\"," +
-                    "\"profile\":\"http://iiif.io/api/annex/services/physdim\"," +
-                    "\"physicalScale\":0.0025," +
-                    "\"physicalUnits\":\"in\"}" +
-                "}", uri);
+        tester.testAuthorizationWhenUnauthorized(uri);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/test/Assert/HTTPAssert.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/test/Assert/HTTPAssert.java
@@ -62,26 +62,6 @@ public final class HTTPAssert {
         assertRepresentationContains(contains, uri.toString());
     }
 
-    public static void assertRepresentationEquals(String expected,
-                                                  String uri) {
-        Client client = newClient();
-        try {
-            client.setURI(new URI(uri));
-            Response response = client.send();
-            assertEquals(expected, response.getBodyAsString());
-        } catch (ResourceException e) {
-            assertEquals(expected, e.getResponse().getBodyAsString());
-        } catch (Exception e) {
-            fail(e.getMessage());
-        } finally {
-            stopQuietly(client);
-        }
-    }
-
-    public static void assertRepresentationEquals(String equals, URI uri) {
-        assertRepresentationEquals(equals, uri.toString());
-    }
-
     public static void assertRepresentationsNotSame(URI uri1, URI uri2) {
         Client client = newClient();
         try {


### PR DESCRIPTION
Closes #580. That issue attempts to explain why I think changing only the 401 responses for information requests is better than changing all 4xx responses.