### PR TITLE
Avoid communicating with S3 unless necessary

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/source/S3ObjectInfoSupplier.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/source/S3ObjectInfoSupplier.java
@@ -1,0 +1,11 @@
+package edu.illinois.library.cantaloupe.source;
+
+import java.io.IOException;
+
+/**
+ * Deferred accessor to {@link S3ObjectInfo}.
+ */
+@FunctionalInterface
+public interface S3ObjectInfoSupplier {
+    S3ObjectInfo get() throws IOException;
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/source/S3Source.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/source/S3Source.java
@@ -422,9 +422,11 @@ final class S3Source extends AbstractSource implements Source {
 
     @Override
     public StreamFactory newStreamFactory() throws IOException {
-        S3ObjectInfo info = getObjectInfo();
-        info.setLength(getObjectAttributes().length);
-        return new S3StreamFactory(info);
+        return new S3StreamFactory(() -> {
+            S3ObjectInfo info = getObjectInfo();
+            info.setLength(getObjectAttributes().length);
+            return info;
+        });
     }
 
     @Override

--- a/src/main/java/edu/illinois/library/cantaloupe/source/S3StreamFactory.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/source/S3StreamFactory.java
@@ -24,14 +24,15 @@ class S3StreamFactory implements StreamFactory {
     private static final int DEFAULT_CHUNK_SIZE       = 1024 * 512;
     private static final int DEFAULT_CHUNK_CACHE_SIZE = 1024 * 1024 * 10;
 
-    private S3ObjectInfo objectInfo;
+    private S3ObjectInfoSupplier objectInfo;
 
-    S3StreamFactory(S3ObjectInfo objectInfo) {
+    S3StreamFactory(S3ObjectInfoSupplier objectInfo) {
         this.objectInfo = objectInfo;
     }
 
     @Override
     public InputStream newInputStream() throws IOException {
+        final S3ObjectInfo objectInfo = this.objectInfo.get();
         final InputStream responseStream =
                 S3Source.newObjectInputStream(objectInfo);
 
@@ -100,6 +101,7 @@ class S3StreamFactory implements StreamFactory {
             LOGGER.debug("newSeekableStream(): using {}-byte chunks",
                     chunkSize);
 
+            final S3ObjectInfo objectInfo = this.objectInfo.get();
             final S3HTTPImageInputStreamClient client =
                     new S3HTTPImageInputStreamClient(objectInfo);
 

--- a/src/test/java/edu/illinois/library/cantaloupe/source/S3StreamFactoryTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/source/S3StreamFactoryTest.java
@@ -109,7 +109,7 @@ public class S3StreamFactoryTest extends BaseTest {
         info.setKey(FIXTURE_KEY);
         info.setLength(1584);
 
-        instance = new S3StreamFactory(info);
+        instance = new S3StreamFactory(() -> info);
     }
 
     @Test


### PR DESCRIPTION
Previously the S3 source would eagerly connect to S3 retrieve information about the object being requested when creating a stream. This change defers retrieval of properties from S3 until needed by the S3StreamFactory, and allows cached files to be served directly from disk with no intermediate S3 lookups.

It's a small optimization, but can shave a dozen or so MS off of a cached image request.