### PR TITLE
Add missing WebIdentityTokenFileCredentialsProvider for S3ClientBuilder to allow use within EKS IRSA scenario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,11 @@
             <artifactId>s3</artifactId>
             <version>${aws-sdk.version}</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>${aws-sdk.version}</version>
+        </dependency>
         <!--
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/util/S3ClientBuilder.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvide
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -72,6 +73,7 @@ public final class S3ClientBuilder {
                 }
             }));
         }
+        builder.addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.builder().build());
         builder.addCredentialsProvider(ProfileCredentialsProvider.create());
         builder.addCredentialsProvider(ContainerCredentialsProvider.builder().build());
         builder.addCredentialsProvider(InstanceProfileCredentialsProvider.builder().build());


### PR DESCRIPTION
Related to https://github.com/cantaloupe-project/cantaloupe/issues/637

I'm not a Java developer, so I'm not sure if this is right in any way, other than we do build with this patch and run it in production successfully. I welcome anything I can do to make this acceptable.