### PR TITLE
Use gray subsampling for grayscale images

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriter.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriter.java
@@ -167,6 +167,11 @@ public final class TurboJPEGImageWriter {
         image = Java2DUtil.removeAlpha(image, bgColor);
         image = Java2DUtil.convertCustomToRGB(image);
 
+        // Gray subsampling required to handle grayscale input
+        if (image.getType() == BufferedImage.TYPE_BYTE_GRAY) {
+            setSubsampling(TJ.SAMP_GRAY);
+        }
+
         try (TJCompressor tjc = new TJCompressor()) {
             tjc.setSubsamp(subsampling);
             tjc.setJPEGQuality(quality);

--- a/src/test/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriterTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriterTest.java
@@ -165,6 +165,17 @@ public class TurboJPEGImageWriterTest extends BaseTest {
     }
 
     @Test
+    public void testWriteWithGrayBufferedImage() throws Exception {
+        BufferedImage image = new BufferedImage(50, 50,
+                BufferedImage.TYPE_BYTE_GRAY);
+
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            instance.write(image, os);
+            assertDimensions(os, image.getWidth(), image.getHeight());
+        }
+    }
+
+    @Test
     public void testWriteWithBufferedImageWithBackgroundColor()
             throws Exception {
         BufferedImage image = new BufferedImage(50, 50,


### PR DESCRIPTION
Fixes error when source image is grayscale jp2