### PR TITLE
ISSUE-593: Fix Virtual Cropping detection condition to take both Y and X in account

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriter.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/TurboJPEGImageWriter.java
@@ -155,7 +155,7 @@ public final class TurboJPEGImageWriter {
         // Also, JPEG doesn't support alpha, so we have to remove that,
         // otherwise readers will interpret as CMYK.
         if (image.getRaster().getSampleModelTranslateX() < 0 ||
-                image.getRaster().getSampleModelTranslateX() < 0) {
+                image.getRaster().getSampleModelTranslateY() < 0) {
             BufferedImage newImage = new BufferedImage(
                     image.getWidth(), image.getHeight(),
                     BufferedImage.TYPE_INT_RGB);


### PR DESCRIPTION
# What?

See #593

Fixes a bug generated by a small typo. Without this fix, PDF tile generation will only result in a single axis being tiled.

