### PR TITLE
Fix some unsafe reads.

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/exif/Reader.java
@@ -155,10 +155,7 @@ public final class Reader implements AutoCloseable {
 
     private byte[] readBytes(int length) throws IOException {
         byte[] data = new byte[length];
-        int n, offset = 0;
-        while ((n = inputStream.read(data, offset, data.length - offset)) < offset) {
-            offset += n;
-        }
+        inputStream.readFully(data);
         return data;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/gif/GIFMetadataReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/gif/GIFMetadataReader.java
@@ -340,11 +340,7 @@ final class GIFMetadataReader implements AutoCloseable {
 
     private byte[] read(int length) throws IOException {
         byte[] data = new byte[length];
-        int n, offset = 0;
-        while ((n = inputStream.read(
-                data, offset, data.length - offset)) < offset) {
-            offset += n;
-        }
+        inputStream.readFully(data);
         return data;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/JPEGMetadataReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg/JPEGMetadataReader.java
@@ -296,11 +296,7 @@ public final class JPEGMetadataReader {
 
     private byte[] read(int length) throws IOException {
         byte[] data = new byte[length];
-        int n, offset = 0;
-        while ((n = inputStream.read(
-                data, offset, data.length - offset)) < offset) {
-            offset += n;
-        }
+        inputStream.readFully(data);
         return data;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000MetadataReader.java
@@ -434,11 +434,7 @@ public final class JPEG2000MetadataReader implements AutoCloseable {
 
     private byte[] read(int length) throws IOException {
         byte[] data = new byte[length];
-        int n, offset = 0;
-        while ((n = inputStream.read(
-                data, offset, data.length - offset)) < offset) {
-            offset += n;
-        }
+        inputStream.readFully(data);
         return data;
     }
 


### PR DESCRIPTION
If they failed to read the number of bytes, the return of `-1` would cause infinite loops, with `-1` always less than the minimum `offset` of `0`.

An alternative to #551 fixing #550, and more, touching on https://github.com/cantaloupe-project/cantaloupe/pull/551#discussion_r1427377512 

Did a bit of a `grep` around for similar broken patterns which should get a similar fix; though, there may be some others. In particular, suspicious of [this bit of `JPEG2000KakaduImageReader`](https://github.com/cantaloupe-project/cantaloupe/blob/21057cf72071840e2a984450bf8845c6e6490ec9/src/main/java/edu/illinois/library/cantaloupe/processor/codec/jpeg2000/JPEG2000KakaduImageReader.java#L103-L110), but not terribly sure on the expectations around it, and don't use Kakadu.