### PR TITLE
Upgrade maven-assembly-plugin to 3.7.1 - CVE-2023-37460

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.1</version>
             <type>maven-plugin</type>
         </dependency>
         <!-- Used by S3Source & S3Cache -->
@@ -502,7 +502,7 @@
             <!-- Assemble the JAR into a release package. -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
see #673, in which I explain that I'm not used to the Java ecosystem and I'm interested in advice on how to solve this correctly if this PR is not the right way. 

This bumps plexus-archiver to 4.9.2, which fixes CVE-2023-37460 (starting from 4.8)
 
 see:  
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317220&version=12353243
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317220&version=12354406
- https://nvd.nist.gov/vuln/detail/CVE-2023-37460

