### PR TITLE
Include S3 object content type in attributes

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/source/S3Source.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/source/S3Source.java
@@ -29,11 +29,7 @@ import java.net.URISyntaxException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 /**
  * <p>Maps an identifier to an <a href="https://aws.amazon.com/s3/">Amazon
@@ -326,6 +322,7 @@ final class S3Source extends AbstractSource implements Source {
                         .build());
                 objectAttributes              = new S3ObjectAttributes();
                 objectAttributes.length       = response.contentLength();
+                objectAttributes.contentType  = response.contentType();
                 objectAttributes.lastModified = response.lastModified();
             } catch (NoSuchBucketException | NoSuchKeyException e) {
                 throw new NoSuchFileException(info.toString());


### PR DESCRIPTION
The `ContentTypeHeaderChecker` is invoked after the `NameChecker`, but the `contentType` is never set when the attributes are fetched from S3. This patch fixes that.