### PR TITLE
Prevent file handle leak during individual purge

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
@@ -508,8 +508,8 @@ class FilesystemCache implements SourceCache, DerivativeCache {
                 hashedPathFragment(identifier.toString()));
         final String expectedNamePrefix =
                 StringUtils.md5(identifier.toString());
-        try {
-            return Files.list(cachePath)
+        try (final var fileStream = Files.list(cachePath)) {
+            return fileStream
                     .filter(p -> p.getFileName().toString().startsWith(expectedNamePrefix))
                     .collect(Collectors.toUnmodifiableSet());
         } catch (NoSuchFileException e) {


### PR DESCRIPTION
https://github.com/cantaloupe-project/cantaloupe/issues/706

Use a try-with-resource block when getting the stream of files in derivative directory to avoid file handle leak