### PR TITLE
disable JRuby's Variable Sharing feature

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/delegate/JRubyDelegateProxy.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/delegate/JRubyDelegateProxy.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.script.Invocable;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -71,6 +72,14 @@ final class JRubyDelegateProxy implements DelegateProxy {
         System.setProperty("org.jruby.embed.localvariable.behavior", "transient");
 
         scriptEngine = new ScriptEngineManager().getEngineByName("jruby");
+
+        // Workaround for a memory leak in JRuby's BiVariableMap: By default, all
+        // instance variables are stored into BiVariableMap so they are accessible
+        // from Java. However, there is currently no mechanism for ever removing
+        // them, forming a memory leak.
+        // That feature isn't used by Cantaloupe, so we can just disable it.
+        scriptEngine.getContext().setAttribute("org.jruby.embed.sharing.variables",
+                false, ScriptContext.ENGINE_SCOPE);
     }
 
     /**


### PR DESCRIPTION
This avoids a memory leak in JRuby 9.4.3.0 (probably at least 9.4.x).

If Variable Sharing is enabled, JRuby stores all Ruby instance variables into a `BiVariableMap` object for access from Java. As of the current 9.4.10.0 development version, this `BiVariable` object is never removed from its `BiVariableMap`, and thus never gets garbage-collected. `JRubyDelegateProxy` creates a new instance of the Ruby `CustomDelegate` object, so any use of instance variables in that object leaks a bit of memory after each request. This eventually grinds Cantaloupe to a halt.

Disabling Variable Sharing is a workaround until this can be fixed in JRuby. JRuby's Variable Sharing feature isn't needed by the code in `JRubyDelegateProxy`.

This memory leak is similar to the one described in #712, but the mechanism is slightly different. I'm proposing the workaround because according to synthetic tests, it should also reduce the impact of that other leak quite significantly.