### PR TITLE
Remove deprecated version in compose.yaml

### DIFF
--- a/docker/Linux-GraalVM-JDK21/compose.yaml
+++ b/docker/Linux-GraalVM-JDK21/compose.yaml
@@ -3,7 +3,6 @@
 #
 # docker compose -f path/to/compose.yaml up --exit-code-from cantaloupe
 #
-version: "3"
 services:
   cantaloupe:
     build:


### PR DESCRIPTION
> /home/runner/work/cantaloupe/cantaloupe/docker/Linux-GraalVM20/compose.yaml: `version` is obsolete"