### PR TITLE
ISSUE-724: Fixes access to frames other than 1 for Video

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/image/Info.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/Info.java
@@ -407,7 +407,12 @@ public final class Info {
      * @return Size of the image at the given index.
      */
     public Dimension getSize(int imageIndex) {
-        return images.get(imageIndex).getSize();
+        if (!isVideo()) {
+            return images.get(imageIndex).getSize();
+        }
+        else {
+            return images.get(0).getSize(); 
+        }
     }
 
     /**
@@ -456,6 +461,14 @@ public final class Info {
                 .map(Image::getSize)
                 .collect(Collectors.toUnmodifiableList());
         return Dimension.isPyramid(sizes);
+    }
+
+     /**
+     * @return Whether resource is a Video
+     * @since  5.0
+     */
+    public boolean isVideo() {
+        return getMediaType().toFormat().isVideo();
     }
 
     /**

--- a/src/main/java/edu/illinois/library/cantaloupe/image/Info.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/Info.java
@@ -468,7 +468,12 @@ public final class Info {
      * @since  5.0
      */
     public boolean isVideo() {
-        return getMediaType().toFormat().isVideo();
+        if (getMediaType() != null) {
+            return getMediaType().toFormat().isVideo();
+        }
+        else {
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/edu/illinois/library/cantaloupe/image/InfoTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/image/InfoTest.java
@@ -966,6 +966,26 @@ class InfoTest extends BaseTest {
         assertEquals(format, instance.getSourceFormat());
     }
 
+
+     /* isVideo() */
+
+     @Test
+     void testIsVideo() {
+         Format format = Format.get("mov");
+         instance.setSourceFormat(format);
+         assertTrue(instance.isVideo());
+     }
+
+     /* isVideo() */
+
+     @Test
+     void testIsNotVideo() {
+         Format format = Format.get("png");
+         instance.setSourceFormat(format);
+         assertFalse(instance.isVideo());
+     }
+
+
     /* toJSON() */
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/processor/FfmpegProcessorTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/processor/FfmpegProcessorTest.java
@@ -123,6 +123,12 @@ public class FfmpegProcessorTest extends AbstractProcessorTest {
     }
 
     @Test
+    void testProcessWithPageIndexInfoIsVideo() throws Exception {
+        final Info imageInfo = instance.readInfo();
+        assertTrue(imageInfo.isVideo());
+    }
+
+    @Test
     void testSupportsSourceFormatWithSupportedFormat() {
         try (Processor instance = newInstance()) {
             assertTrue(instance.supportsSourceFormat(Format.get("mp4")));


### PR DESCRIPTION
See #724 

The way I approached is:
- least intrusive/effort (to avoid modifying the N+1 places we access getSize(pageIndex) all over the place
- Simplest to test by tapping into the Info Class itself, which is not V1/V2/V3 specific like all the other resources

Added a few basic tests. Funny enough, our resource tests don't really use the Info class many times ... but I hope this covers it 

FYI: this works