### PR TITLE
Allow spaces in the `format` argument of `FormatException`

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/FormatException.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/FormatException.java
@@ -3,7 +3,7 @@ package edu.illinois.library.cantaloupe.resource.iiif;
 public class FormatException extends IllegalArgumentException {
 
     public FormatException(String format) {
-        super("Unsupported format: " + format.replaceAll("[^A-Za-z0-9]", ""));
+        super("Unsupported format: " + format.replaceAll("[^A-Za-z0-9 ]", ""));
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/FormatException.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/FormatException.java
@@ -3,7 +3,7 @@ package edu.illinois.library.cantaloupe.resource.iiif;
 public class FormatException extends IllegalArgumentException {
 
     public FormatException(String format) {
-        super("Unsupported format: " + format.replaceAll("[^A-Za-z0-9 ]", ""));
+        super("Unsupported format: " + format.replaceAll("[^A-Za-z0-9 .]", ""));
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Parameters.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Parameters.java
@@ -109,7 +109,7 @@ class Parameters {
         try {
             setOutputFormat(OutputFormat.valueOf(format.toUpperCase()));
         } catch (IllegalArgumentException e) {
-            throw new FormatException("Unsupported format. Available output" +
+            throw new FormatException("Unsupported format. Available output " +
                     "formats for this image are listed in the information " +
                     "response.");
         }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Parameters.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Parameters.java
@@ -107,7 +107,7 @@ class Parameters {
         try {
             setOutputFormat(OutputFormat.valueOf(format.toUpperCase()));
         } catch (IllegalArgumentException e) {
-            throw new FormatException("Unsupported format. Available output" +
+            throw new FormatException("Unsupported format. Available output " +
                     "formats for this image are listed in the information " +
                     "response.");
         }


### PR DESCRIPTION
This closes #757. However, I'm open to discuss whether this is the way to go in the issue comments.

When a IIIF v1 endpoint receives a request for an image in an unsupported format, the requested format (i.e. the filename extension) is provided as the `format` argument in a `FormatException`.
When a IIIF v2 or v3 endpoint receives a request for an unsupported format, i.e. a format that is not in the registry, the `format` argument is a help message – a suggestion to look for available formats in the information resource.
The `format` is normalised/cleaned and the result is used to construct a more elaborate error message.

This PR changes the normalisation to allow spaces (but not `.`s that are also in the help messages for v2 and v3) and fixes those help messages by adding a missing space.