### PR TITLE
Use a static locale for producing StringOverlay.toString

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
@@ -8,6 +8,7 @@ import edu.illinois.library.cantaloupe.util.StringUtils;
 
 import java.awt.Font;
 import java.awt.font.TextAttribute;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -204,7 +205,8 @@ public class StringOverlay extends Overlay implements Operation {
     public String toString() {
         // minSize is not included, as it is more of a potential property than
         // a property.
-        return String.format("%s_%s_%d_%s_%d_%.1f_%.01f_%s_%s_%s_%.1f_%s",
+        return String.format(new Locale("en", "UK"),
+                "%s_%s_%d_%s_%d_%.1f_%.01f_%s_%s_%s_%.1f_%s",
                 StringUtils.md5(getString()),
                 getPosition(),
                 getInset(),


### PR DESCRIPTION
This string should be stable across any locale

Fixes #758
