### PR TITLE
ISSUE-771: Fixes Null pointer on gray tiff image (with cropped region/no scaling) for gray|bitonal outputs

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/Java2DUtil.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/Java2DUtil.java
@@ -209,6 +209,24 @@ public final class Java2DUtil {
         return outImage;
     }
 
+
+    /**
+     * @param inImage Image to convert.
+     * @return New image of type {@link BufferedImage#TYPE_INT_ARGB}, or the
+     *         input image if it is not Grayscale.
+     */
+    static BufferedImage convertGrayToARGB(BufferedImage inImage) {
+        BufferedImage outImage = inImage;
+        if (inImage.getType() == BufferedImage.TYPE_BYTE_GRAY) {
+            final Stopwatch watch = new Stopwatch();
+            outImage = new BufferedImage(inImage.getWidth(), inImage.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            ColorConvertOp convert = new ColorConvertOp(null);
+            convert.filter(inImage, outImage);
+            LOGGER.trace("convertGrayToARGB(): executed in {}", watch);
+        }
+        return outImage;
+    }
+
     /**
      * @param inImage Image to convert.
      * @return        New image with a linear RGB color space, or the input
@@ -1124,6 +1142,7 @@ public final class Java2DUtil {
                 break;
             case BITONAL:
                 outImage = convertIndexedToARGB(outImage);
+                outImage = convertGrayToARGB(outImage);
                 binarize(outImage);
                 break;
         }
@@ -1138,8 +1157,9 @@ public final class Java2DUtil {
      * Grayscales the given image's pixels.
      */
     private static void grayscale(BufferedImage image) {
-        for (int y = 0; y < image.getHeight(); y++) {
-            for (int x = 0; x < image.getWidth(); x++) {
+        if (image.getType() != BufferedImage.TYPE_BYTE_GRAY) {
+            for (int y = 0; y < image.getHeight(); y++) {
+                for (int x = 0; x < image.getWidth(); x++) {
                 int argb  = image.getRGB(x, y);
                 int alpha = (argb >> 24) & 0xff;
                 int red   = (argb >> 16) & 0xff;
@@ -1148,6 +1168,7 @@ public final class Java2DUtil {
                 int luma  = (int) (0.21 * red + 0.71 * green + 0.07 * blue);
                 argb      = (alpha << 24) | (luma << 16) | (luma << 8) | luma;
                 image.setRGB(x, y, argb);
+                }
             }
         }
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
@@ -226,13 +226,6 @@ public class ResampleOp extends AdvancedResizeOp {
             srcImage = ImageUtils.convert(srcImage, srcImage.getColorModel().hasAlpha() ?
                     BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
         }
-
-       /*if (srcImage.getType() == BufferedImage.TYPE_CUSTOM &&  srcImage.getSampleModel().getNumBands() == 2) {
-            srcImage = ImageUtils.convert(srcImage, srcImage.getColorModel().hasAlpha() ?
-                    BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
-        }*/
-
-
         this.numChannels = srcImage.getSampleModel().getNumBands();
         assert numChannels > 0;
         this.srcWidth = srcImage.getWidth();
@@ -361,7 +354,7 @@ public class ResampleOp extends AdvancedResizeOp {
 
     private void verticalFromWorkToDstGray(byte[][] workPixels, byte[] outPixels,
                                            int start, int delta) {
-        boolean useChannel1 = false;
+        boolean useChannel1 = numChannels == 2;
         for (int x = start; x < destWidth; x += delta) {
             final int xLocation = x * numChannels;
             for (int y = destHeight - 1; y >= 0; y--) {
@@ -454,7 +447,7 @@ public class ResampleOp extends AdvancedResizeOp {
         final int[] tempPixels = new int[srcWidth];
         // Create reusable row to minimize memory overhead.
         final byte[] srcPixels = new byte[srcWidth * numChannels];
-        boolean useChannel1 = false;
+        final boolean useChannel1 = numChannels == 2 ;
 
         for (int k = start; k < srcHeight; k = k + delta) {
             ImageUtils.readPixelsBGR(srcImage, k, srcWidth, srcPixels, tempPixels);
@@ -462,13 +455,13 @@ public class ResampleOp extends AdvancedResizeOp {
             for (int i = destWidth - 1; i >= 0; i--) {
                 int sampleLocation = i * numChannels;
                 final int max = horizontalSubsamplingData.arrN[i];
-
                 float sample0 = 0.0f;
                 float sample1 = 0.0f;
                 int index = i * horizontalSubsamplingData.numContributors;
+
                 for (int j = max - 1; j >= 0; j--) {
                     float arrWeight = horizontalSubsamplingData.arrWeight[index];
-                    int pixelIndex = horizontalSubsamplingData.arrPixel[index] * numChannels;
+                    int pixelIndex = horizontalSubsamplingData.arrPixel[index];
 
                     sample0 += (srcPixels[pixelIndex] & 0xff) * arrWeight;
                     if (useChannel1) {

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
@@ -226,6 +226,13 @@ public class ResampleOp extends AdvancedResizeOp {
             srcImage = ImageUtils.convert(srcImage, srcImage.getColorModel().hasAlpha() ?
                     BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
         }
+
+       /*if (srcImage.getType() == BufferedImage.TYPE_CUSTOM &&  srcImage.getSampleModel().getNumBands() == 2) {
+            srcImage = ImageUtils.convert(srcImage, srcImage.getColorModel().hasAlpha() ?
+                    BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
+        }*/
+
+
         this.numChannels = srcImage.getSampleModel().getNumBands();
         assert numChannels > 0;
         this.srcWidth = srcImage.getWidth();
@@ -354,7 +361,7 @@ public class ResampleOp extends AdvancedResizeOp {
 
     private void verticalFromWorkToDstGray(byte[][] workPixels, byte[] outPixels,
                                            int start, int delta) {
-        boolean useChannel1 = numChannels == 2;
+        boolean useChannel1 = false;
         for (int x = start; x < destWidth; x += delta) {
             final int xLocation = x * numChannels;
             for (int y = destHeight - 1; y >= 0; y--) {
@@ -447,7 +454,7 @@ public class ResampleOp extends AdvancedResizeOp {
         final int[] tempPixels = new int[srcWidth];
         // Create reusable row to minimize memory overhead.
         final byte[] srcPixels = new byte[srcWidth * numChannels];
-        final boolean useChannel1 = numChannels == 2 ;
+        boolean useChannel1 = false;
 
         for (int k = start; k < srcHeight; k = k + delta) {
             ImageUtils.readPixelsBGR(srcImage, k, srcWidth, srcPixels, tempPixels);
@@ -455,13 +462,13 @@ public class ResampleOp extends AdvancedResizeOp {
             for (int i = destWidth - 1; i >= 0; i--) {
                 int sampleLocation = i * numChannels;
                 final int max = horizontalSubsamplingData.arrN[i];
+
                 float sample0 = 0.0f;
                 float sample1 = 0.0f;
                 int index = i * horizontalSubsamplingData.numContributors;
-
                 for (int j = max - 1; j >= 0; j--) {
                     float arrWeight = horizontalSubsamplingData.arrWeight[index];
-                    int pixelIndex = horizontalSubsamplingData.arrPixel[index];
+                    int pixelIndex = horizontalSubsamplingData.arrPixel[index] * numChannels;
 
                     sample0 += (srcPixels[pixelIndex] & 0xff) * arrWeight;
                     if (useChannel1) {

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
@@ -311,7 +311,7 @@ public class ResampleOp extends AdvancedResizeOp {
 
     private void verticalFromWorkToDst(byte[][] workPixels, byte[] outPixels,
                                        int start, int delta) {
-        if (numChannels < 3) {
+        if (numChannels == 1) {
             verticalFromWorkToDstGray(workPixels, outPixels, start,
                     THREAD_COUNT);
             return;
@@ -354,9 +354,7 @@ public class ResampleOp extends AdvancedResizeOp {
 
     private void verticalFromWorkToDstGray(byte[][] workPixels, byte[] outPixels,
                                            int start, int delta) {
-        boolean useChannel1 = numChannels == 2;
         for (int x = start; x < destWidth; x += delta) {
-            final int xLocation = x * numChannels;
             for (int y = destHeight - 1; y >= 0; y--) {
                 final int yTimesNumContributors =
                         y * verticalSubsamplingData.numContributors;
@@ -364,22 +362,15 @@ public class ResampleOp extends AdvancedResizeOp {
                 final int sampleLocation = (y * destWidth + x);
 
                 float sample0 = 0.0f;
-                float sample1 = 0.0f;
                 int index = yTimesNumContributors;
                 for (int j = max - 1; j >= 0; j--) {
                     int valueLocation = verticalSubsamplingData.arrPixel[index];
                     float arrWeight = verticalSubsamplingData.arrWeight[index];
-                    sample0 += (workPixels[valueLocation][xLocation] & 0xff) * arrWeight;
-                    if (useChannel1) {
-                        sample1 += (workPixels[valueLocation][xLocation + 1] & 0xff) * arrWeight;
-                    }
+                    sample0 += (workPixels[valueLocation][x] & 0xff) * arrWeight;
                     index++;
                 }
 
                 outPixels[sampleLocation] = toByte(sample0);
-                if (useChannel1) {
-                    outPixels[sampleLocation + 1] = toByte(sample1);
-                }
             }
         }
     }
@@ -390,7 +381,7 @@ public class ResampleOp extends AdvancedResizeOp {
     private void horizontalFromSrcToWork(BufferedImage srcImg,
                                          byte[][] workPixels,
                                          int start, int delta) {
-        if (numChannels < 3) {
+        if (numChannels == 1) {
             horizontalFromSrcToWorkGray(srcImg, workPixels, start, delta);
             return;
         }
@@ -446,17 +437,14 @@ public class ResampleOp extends AdvancedResizeOp {
         // values
         final int[] tempPixels = new int[srcWidth];
         // Create reusable row to minimize memory overhead.
-        final byte[] srcPixels = new byte[srcWidth * numChannels];
-        final boolean useChannel1 = numChannels == 2 ;
+        final byte[] srcPixels = new byte[srcWidth];
 
         for (int k = start; k < srcHeight; k = k + delta) {
             ImageUtils.readPixelsBGR(srcImage, k, srcWidth, srcPixels, tempPixels);
 
             for (int i = destWidth - 1; i >= 0; i--) {
-                int sampleLocation = i * numChannels;
                 final int max = horizontalSubsamplingData.arrN[i];
                 float sample0 = 0.0f;
-                float sample1 = 0.0f;
                 int index = i * horizontalSubsamplingData.numContributors;
 
                 for (int j = max - 1; j >= 0; j--) {
@@ -464,16 +452,10 @@ public class ResampleOp extends AdvancedResizeOp {
                     int pixelIndex = horizontalSubsamplingData.arrPixel[index];
 
                     sample0 += (srcPixels[pixelIndex] & 0xff) * arrWeight;
-                    if (useChannel1) {
-                        sample1 += (srcPixels[pixelIndex + 1] & 0xff) * arrWeight;
-                    }
                     index++;
                 }
 
-                workPixels[k][sampleLocation] = toByte(sample0);
-                if (useChannel1) {
-                    workPixels[k][sampleLocation + 1] = toByte(sample1);
-                }
+                workPixels[k][i] = toByte(sample0);
             }
         }
     }

--- a/src/test/java/edu/illinois/library/cantaloupe/processor/Java2DUtilTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/processor/Java2DUtilTest.java
@@ -321,6 +321,23 @@ class Java2DUtilTest extends BaseTest {
         assertEquals(BufferedImage.TYPE_INT_ARGB, outImage.getType());
     }
 
+    /* convertGrayToARGB() */
+
+    @Test
+    void convertGrayToARGB() {
+        BufferedImage inImage, outImage;
+
+        // Color image
+        inImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+        outImage = Java2DUtil.convertGrayToARGB(inImage);
+        assertSame(inImage, outImage);
+
+        // Gray image
+        inImage = new BufferedImage(10, 10, BufferedImage.TYPE_BYTE_GRAY);
+        outImage = Java2DUtil.convertGrayToARGB(inImage);
+        assertEquals(BufferedImage.TYPE_INT_ARGB, outImage.getType());
+    }
+
     /* convertToLinearRGB(BufferedImage) */
 
     @Test
@@ -924,6 +941,75 @@ class Java2DUtilTest extends BaseTest {
         BufferedImage outImage = Java2DUtil.transformColor(inImage,
                 ColorTransform.GRAY);
         assertSame(inImage, outImage);
+    }
+
+    @Test
+    void transformColorFrom8BitGrayToBitonal() {
+        BufferedImage inImage = newGrayImage(8, false);
+
+        // Create a dark gray rectangle, then a light gray one.
+        // The histogram algorithm needs contrast.
+        Graphics2D g2d = inImage.createGraphics();
+        g2d.setColor(new java.awt.Color(5,5,5));
+        g2d.fill(new Rectangle(0, 0, 10, 10).toAWTRectangle());
+        g2d.setColor(new java.awt.Color(192,192,192));
+        g2d.fill(new Rectangle(10, 10, 10, 10).toAWTRectangle());
+        g2d.dispose();
+
+        // Transform to bitonal.
+        BufferedImage outImage = Java2DUtil.transformColor(inImage,
+                ColorTransform.BITONAL);
+
+        // Expect it to be transformed to black.
+        assertRGBA(outImage.getRGB(0, 0), 0, 0, 0, 255);
+
+        // Create a Light gray rectangle, then a dark gray one.
+        g2d = inImage.createGraphics();
+        g2d.setColor(new java.awt.Color(192,192,192));
+        g2d.fill(new Rectangle(0, 0, 10, 10).toAWTRectangle());
+        g2d.setColor(new java.awt.Color(5,5,5));
+        g2d.fill(new Rectangle(10, 10, 10, 10).toAWTRectangle());
+        g2d.dispose();
+
+        // Transform to bitonal.
+        outImage = Java2DUtil.transformColor(inImage, ColorTransform.BITONAL);
+
+        // Expect it to be transformed to white.
+        assertRGBA(outImage.getRGB(0, 0), 255, 255, 255, 255);
+    }
+    @Test
+    void transformColorFrom16BitGrayToBitonal() {
+        BufferedImage inImage = newGrayImage(16, false);
+
+        // Create a dark gray rectangle, then a light gray one.
+        // The histogram algorithm needs contrast.
+        Graphics2D g2d = inImage.createGraphics();
+        g2d.setColor(new java.awt.Color(5,5,5));
+        g2d.fill(new Rectangle(0, 0, 10, 10).toAWTRectangle());
+        g2d.setColor(new java.awt.Color(192,192,192));
+        g2d.fill(new Rectangle(10, 10, 10, 10).toAWTRectangle());
+        g2d.dispose();
+
+        // Transform to bitonal.
+        BufferedImage outImage = Java2DUtil.transformColor(inImage,
+                ColorTransform.BITONAL);
+
+        // Expect it to be transformed to black.
+        assertRGBA(outImage.getRGB(0, 0), 0, 0, 0, 255);
+
+        // Create a Light gray rectangle, then a dark gray one.
+        g2d = inImage.createGraphics();
+        g2d.setColor(new java.awt.Color(192,192,192));
+        g2d.fill(new Rectangle(0, 0, 10, 10).toAWTRectangle());
+        g2d.setColor(new java.awt.Color(5,5,5));
+        g2d.fill(new Rectangle(10, 10, 10, 10).toAWTRectangle());
+        g2d.dispose();
+
+        // Transform to bitonal.
+        outImage = Java2DUtil.transformColor(inImage, ColorTransform.BITONAL);
+
+        // Expect it to be transformed to white.
+        assertRGBA(outImage.getRGB(0, 0), 255, 255, 255, 255);
     }
 
     @Test


### PR DESCRIPTION
See #771 

Includes also Tests 👀 , new and missing ones

Happy to try other approaches? but this bug is killing a Gray Scale heavy instance we have