### PR TITLE
Remove deprecated illegal-access argument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
                     <reuseForks>false</reuseForks>
                     <!-- JAI requires this in JDK >= 16. -->
                     <!-- JAI requires this in JDK 16+. It should be removed when JAI is. -->
-                    <argLine>--illegal-access=permit --add-opens java.desktop/sun.awt.image=ALL-UNNAMED</argLine>
+                    <argLine>--add-opens java.desktop/sun.awt.image=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This no longer has an effect in Java 17+