### PR TITLE
Upgrade dependency-check-maven to 12.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>9.0.9</version>
+                <version>12.1.3</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Seeing this with v 9:
```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:9.0.9:check (default) on project cantaloupe: Fatal exception(s) analyzing Cantaloupe: One or more exceptions occurred during analysis:
[ERROR] 	UpdateException: Error updating the NVD Data; the NVD returned a 403 or 404 error
[ERROR]
[ERROR] Consider using an NVD API Key; see https://github.com/jeremylong/DependencyCheck?tab=readme-ov-file#nvd-api-key-highly-recommended
[ERROR] 	NoDataException: No documents exist
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```