### PR TITLE
Fix content negotiation

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
@@ -208,11 +208,11 @@ public abstract class AbstractResource {
         Method[] methods = getSupportedMethods();
         if (methods.length > 0) {
             response.setStatus(Status.NO_CONTENT.getCode());
-            response.setHeader("Allow", Arrays.stream(methods)
+            response.setHeader("Access-Control-Allow-Methods", Arrays.stream(methods)
                     .map(Method::toString)
                     .collect(Collectors.joining(",")));
         } else {
-            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
+            response.setStatus(Status.NOT_ACCEPTABLE.getCode());
         }
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
@@ -53,11 +53,11 @@ public class InformationResource extends IIIF1Resource {
         if (methods.length > 0) {
             response.setStatus(Status.NO_CONTENT.getCode());
             response.setHeader("Access-Control-Allow-Headers", "Authorization");
-            response.setHeader("Allow", Arrays.stream(methods)
+            response.setHeader("Access-Control-Allow-Methods", Arrays.stream(methods)
                     .map(Method::toString)
                     .collect(Collectors.joining(",")));
         } else {
-            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
+            response.setStatus(Status.NOT_ACCEPTABLE.getCode());
         }
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
@@ -55,11 +55,11 @@ public class InformationResource extends IIIF2Resource {
         if (methods.length > 0) {
             response.setStatus(Status.NO_CONTENT.getCode());
             response.setHeader("Access-Control-Allow-Headers", "Authorization");
-            response.setHeader("Allow", Arrays.stream(methods)
+            response.setHeader("Access-Control-Allow-Methods", Arrays.stream(methods)
                     .map(Method::toString)
                     .collect(Collectors.joining(",")));
         } else {
-            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
+            response.setStatus(Status.NOT_ACCEPTABLE.getCode());
         }
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
@@ -55,11 +55,11 @@ public class InformationResource extends IIIF3Resource {
         if (methods.length > 0) {
             response.setStatus(Status.NO_CONTENT.getCode());
             response.setHeader("Access-Control-Allow-Headers", "Authorization");
-            response.setHeader("Allow", Arrays.stream(methods)
+            response.setHeader("Access-Control-Allow-Methods", Arrays.stream(methods)
                     .map(Method::toString)
                     .collect(Collectors.joining(",")));
         } else {
-            response.setStatus(Status.METHOD_NOT_ALLOWED.getCode());
+            response.setStatus(Status.NOT_ACCEPTABLE.getCode());
         }
     }
 

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/LandingResourceTest.java
@@ -61,7 +61,7 @@ public class LandingResourceTest extends ResourceTest {
         assertEquals(204, response.getStatus());
 
         Headers headers = response.getHeaders();
-        List<String> methods = List.of(headers.getFirstValue("Allow").split(","));
+        List<String> methods = List.of(headers.getFirstValue("Access-Control-Allow-Methods").split(","));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AbstractAdminResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AbstractAdminResourceTest.java
@@ -44,7 +44,7 @@ abstract class AbstractAdminResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResourceTest.java
@@ -90,7 +90,7 @@ public class ConfigurationResourceTest extends AbstractAdminResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(3, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("PUT"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/api/AbstractAPIResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/api/AbstractAPIResourceTest.java
@@ -68,7 +68,7 @@ abstract class AbstractAPIResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/api/ConfigurationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/api/ConfigurationResourceTest.java
@@ -93,7 +93,7 @@ public class ConfigurationResourceTest extends AbstractAPIResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(3, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("PUT"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/api/TasksResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/api/TasksResourceTest.java
@@ -47,7 +47,7 @@ public class TasksResourceTest extends AbstractAPIResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("POST"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResourceTest.java
@@ -586,7 +586,7 @@ public class ImageResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
@@ -599,7 +599,7 @@ public class InformationResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/LandingResourceTest.java
@@ -91,7 +91,7 @@ public class LandingResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResourceTest.java
@@ -708,7 +708,7 @@ public class ImageResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
@@ -619,7 +619,7 @@ public class InformationResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/LandingResourceTest.java
@@ -91,7 +91,7 @@ public class LandingResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
@@ -658,7 +658,7 @@ public class ImageResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
@@ -596,7 +596,7 @@ public class InformationResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/LandingResourceTest.java
@@ -91,7 +91,7 @@ class LandingResourceTest extends ResourceTest {
 
         Headers headers = response.getHeaders();
         List<String> methods =
-                List.of(StringUtils.split(headers.getFirstValue("Allow"), ", "));
+                List.of(StringUtils.split(headers.getFirstValue("Access-Control-Allow-Methods"), ", "));
         assertEquals(2, methods.size());
         assertTrue(methods.contains("GET"));
         assertTrue(methods.contains("OPTIONS"));


### PR DESCRIPTION
The Allow header is not for a list of methods. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Allow

When 405 is returned, then Allow is required to be provided and be a list of methods: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/405