### PR TITLE
Fix redirect to align with the documentation

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/resource/TrailingSlashRemovingResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/TrailingSlashRemovingResource.java
@@ -30,10 +30,9 @@ public class TrailingSlashRemovingResource extends AbstractResource {
     public void doGET() {
         final Reference newRef = new Reference(getRequest().getPublicReference());
         final String path = newRef.getPath();
-        newRef.setPath(path.substring(0, path.length() - 1));
 
         getResponse().setStatus(Status.MOVED_PERMANENTLY.getCode());
-        getResponse().setHeader("Location", newRef.toString());
+        getResponse().setHeader("Location", path.substring(0, path.length() - 1));
     }
 
 }

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/TrailingSlashRemovingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/TrailingSlashRemovingResourceTest.java
@@ -33,8 +33,9 @@ public class TrailingSlashRemovingResourceTest extends ResourceTest {
         Response response = client.send();
 
         assertEquals(301, response.getStatus());
+
         assertTrue(response.getHeaders().getFirstValue("Location").
-                endsWith("/cats" + getEndpointPath()));
+                equals("/cats" + getEndpointPath()));
         assertTrue(response.getBodyAsString().isEmpty());
     }
 

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/LandingResourceTest.java
@@ -45,8 +45,7 @@ public class LandingResourceTest extends ResourceTest {
 
     @Test
     void testGETWithTrailingSlashRedirectsToWithout() throws Exception {
-        final URI uri = getHTTPURI("");
-        assertRedirect(new URI(uri + "/"), uri, 301);
+        assertRedirect(getHTTPURI("/"), Route.IIIF_1_PATH, 301);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/LandingResourceTest.java
@@ -45,8 +45,7 @@ public class LandingResourceTest extends ResourceTest {
 
     @Test
     void testGETWithTrailingSlashRedirectsToWithout() throws Exception {
-        final URI uri = getHTTPURI("");
-        assertRedirect(new URI(uri + "/"), uri, 301);
+        assertRedirect(getHTTPURI("/"), Route.IIIF_2_PATH, 301);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/LandingResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/LandingResourceTest.java
@@ -45,8 +45,7 @@ class LandingResourceTest extends ResourceTest {
 
     @Test
     void testGETWithTrailingSlashRedirectsToWithout() throws Exception {
-        final URI uri = getHTTPURI("");
-        assertRedirect(new URI(uri + "/"), uri, 301);
+        assertRedirect(getHTTPURI("/"), Route.IIIF_3_PATH, 301);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/test/Assert/HTTPAssert.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/test/Assert/HTTPAssert.java
@@ -28,11 +28,15 @@ public final class HTTPAssert {
     }
 
     public static void assertRedirect(URI fromURI, URI toURI, int status) {
+        assertRedirect(fromURI, toURI.toString(), status);
+    }
+
+    public static void assertRedirect(URI fromURI, String toLocation, int status) {
         Client client = newClient();
         try {
             client.setURI(fromURI);
             Response response = client.send();
-            assertEquals(toURI.toString(),
+            assertEquals(toLocation,
                     response.getHeaders().getFirstValue("Location"));
             assertEquals(status, response.getStatus());
         } catch (Exception e) {


### PR DESCRIPTION
Previously it was redirecting to a full URI, but the documentation of the method indicates it should redirect to a path.

See documentation:
https://github.com/cantaloupe-project/cantaloupe/blob/646e89b14639b4f1daaa322f5bc40aa42cb00b4a/src/main/java/edu/illinois/library/cantaloupe/resource/TrailingSlashRemovingResource.java#L10-L11