### PR TITLE
Extract ScaleValidator from IIIFResource

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
@@ -250,31 +250,6 @@ public abstract class IIIFResource extends AbstractResource {
         return false;
     }
 
-    /**
-     * @param virtualSize   Orientation-aware full source image size.
-     * @param scale         May be {@code null}.
-     * @param invalidStatus Status code to return when the given scale fails
-     *                      validation.
-     */
-    protected void validateScale(Dimension virtualSize,
-                                 Scale scale,
-                                 Status invalidStatus) throws ScaleRestrictedException {
-        final ScaleConstraint scaleConstraint =
-                (getMetaIdentifier().getScaleConstraint() != null) ?
-                getMetaIdentifier().getScaleConstraint() : new ScaleConstraint(1, 1);
-        double scalePct = scaleConstraint.getRational().doubleValue();
-        if (scale != null) {
-            scalePct = Arrays.stream(
-                    scale.getResultingScales(virtualSize, scaleConstraint))
-                    .max().orElse(1);
-        }
-        final Configuration config = Configuration.getInstance();
-        final double maxScale      = config.getDouble(Key.MAX_SCALE, 1.0);
-        if (maxScale > 0.0001 && scalePct > maxScale) {
-            throw new ScaleRestrictedException(invalidStatus, maxScale);
-        }
-    }
-    
     protected void setLastModifiedHeader(Instant lastModified) {
         getResponse().setHeader("Last-Modified",
                 DateTimeFormatter.RFC_1123_DATE_TIME

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidator.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidator.java
@@ -1,0 +1,45 @@
+package edu.illinois.library.cantaloupe.resource.iiif;
+
+import java.util.Arrays;
+
+import edu.illinois.library.cantaloupe.config.Configuration;
+import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.http.Status;
+import edu.illinois.library.cantaloupe.image.Dimension;
+import edu.illinois.library.cantaloupe.image.MetaIdentifier;
+import edu.illinois.library.cantaloupe.image.ScaleConstraint;
+import edu.illinois.library.cantaloupe.operation.Scale;
+import edu.illinois.library.cantaloupe.resource.ScaleRestrictedException;
+
+/**
+ * Shared scale validation logic for IIIF.
+ * Note that there is an additional scale validator contained within v3.ImageResource
+ */
+public class ScaleValidator {
+    
+    /**
+     * @param virtualSize   Orientation-aware full source image size.
+     * @param scale         May be {@code null}.
+     * @param invalidStatus Status code to return when the given scale fails
+     *                      validation.
+     */
+    public static void validateScale(Dimension virtualSize,
+                                 Scale scale,
+                                 Status invalidStatus,
+                                 MetaIdentifier metaId) throws ScaleRestrictedException {
+        final ScaleConstraint scaleConstraint = (metaId.getScaleConstraint() != null) ?
+                metaId.getScaleConstraint() : new ScaleConstraint(1, 1);
+        double scalePct = scaleConstraint.getRational().doubleValue();
+        if (scale != null) {
+            scalePct = Arrays.stream(
+                    scale.getResultingScales(virtualSize, scaleConstraint))
+                    .max().orElse(1);
+        }
+        final Configuration config = Configuration.getInstance();
+        final double maxScale      = config.getDouble(Key.MAX_SCALE, 1.0);
+        if (maxScale > 0.0001 && scalePct > maxScale) {
+            throw new ScaleRestrictedException(invalidStatus, maxScale);
+        }
+    }
+    
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResource.java
@@ -14,6 +14,8 @@ import edu.illinois.library.cantaloupe.processor.Processor;
 import edu.illinois.library.cantaloupe.resource.ImageRequestHandler;
 import edu.illinois.library.cantaloupe.source.StatResult;
 import edu.illinois.library.cantaloupe.http.ContentTypeNegotiator;
+import edu.illinois.library.cantaloupe.resource.iiif.ScaleValidator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,9 +100,10 @@ public class ImageResource extends IIIF1Resource {
             public void willProcessImage(Processor processor,
                                          Info info) throws Exception {
                 final Dimension fullSize = info.getSize(getPageIndex());
-                validateScale(info.getMetadata().getOrientation().adjustedSize(fullSize),
+                ScaleValidator.validateScale(info.getMetadata().getOrientation().adjustedSize(fullSize),
                         (Scale) opList.getFirst(Scale.class),
-                        Status.FORBIDDEN);
+                        Status.FORBIDDEN,
+                        getMetaIdentifier());
 
                 final String disposition = getRepresentationDisposition(
                         getMetaIdentifier().toString(),

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResource.java
@@ -17,6 +17,7 @@ import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.ImageRequestHandler;
 import edu.illinois.library.cantaloupe.resource.iiif.SizeRestrictedException;
 import edu.illinois.library.cantaloupe.source.StatResult;
+import edu.illinois.library.cantaloupe.resource.iiif.ScaleValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,10 +123,12 @@ public class ImageResource extends IIIF2Resource {
                         metadata.getOrientation() : Orientation.ROTATE_0;
                 final Dimension virtualSize   = orientation.adjustedSize(info.getSize(pageIndex));
                 final Dimension resultingSize = ops.getResultingSize(info.getSize());
-                validateScale(
+                ScaleValidator.validateScale(
                         virtualSize,
                         (Scale) ops.getFirst(Scale.class),
-                        Status.FORBIDDEN);
+                        Status.FORBIDDEN,
+                        getMetaIdentifier());
+                
                 validateSize(resultingSize, virtualSize);
                 sendHeaders();
             }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
@@ -19,6 +19,8 @@ import edu.illinois.library.cantaloupe.resource.ScaleRestrictedException;
 import edu.illinois.library.cantaloupe.resource.ImageRequestHandler;
 import edu.illinois.library.cantaloupe.resource.iiif.SizeRestrictedException;
 import edu.illinois.library.cantaloupe.source.StatResult;
+import edu.illinois.library.cantaloupe.resource.iiif.ScaleValidator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,7 +129,7 @@ public class ImageResource extends IIIF3Resource {
                 final Dimension virtualSize   = orientation.adjustedSize(info.getSize(pageIndex));
                 final Dimension resultingSize = ops.getResultingSize(info.getSize(pageIndex));
                 validateScale(virtualSize, scale, params.getSize().isUpscalingAllowed());
-                validateScale(virtualSize, scale, Status.BAD_REQUEST);
+                ScaleValidator.validateScale(virtualSize, scale, Status.BAD_REQUEST, getMetaIdentifier());
                 validateSize(virtualSize, resultingSize);
                 sendHeaders();
             }


### PR DESCRIPTION
The IIIFResource method is a controller method and to be cohesive, it shouldn't need to know about how to validate the scale of a transformation.