### PR TITLE
ISSUE-870: (Pass2) Exceptions are different when called first time v/s afterwards 

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/KakaduNativeProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/KakaduNativeProcessor.java
@@ -103,10 +103,12 @@ class KakaduNativeProcessor implements FileProcessor, StreamProcessor {
         initializeClass();
         try {
             reader = new JPEG2000KakaduImageReader();
-        } catch (UnsatisfiedLinkError ignore) {
-            // This will be thrown if Kakadu failed to initialize,
-            // which would happen if Kakadu Libs are not available. It's
-            // swallowed because this isn't the place to handle it.
+        } catch (NoClassDefFoundError | UnsatisfiedLinkError ignore) {
+            // UnsatisfiedLinkError will be thrown on a first
+            // initialization attempt, if Kakadu Libs are not available. 
+            // But on consequente ones, the class itself will be missing. 
+            // Both are swallowed because this isn't the place to 
+            // handle it.
         }
     }
 


### PR DESCRIPTION
...when Kakadu Libraries are absent

See #870 

This covers *using the current implementation* both type of exceptions
- First time: UnsatisfiedLinkError
- Once initialization attempt was made: NoClassDefFoundError (VM unloads the `JPEG2000KakaduImageReader` class?)

There are a few issues with this whole thing as stated in #876 , but a new, and most obvious one here, is also that the reset method does not reset the error message ... and bc really that is what is used *(since we have so many ignored catches) to define if a processor is available or not, at least not for this, but for others that could be not available, bc of wrong configs, you can't just reset it's failed state....

Still committing, since this matches the way other processors are handled when there is a failure and thus consistent with the current architecture.