### PR TITLE
ISSUE-879: Revert "Upgrade to latest version of imageio-ext-tiff"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,11 @@
         <dependency>
             <groupId>it.geosolutions.imageio-ext</groupId>
             <artifactId>imageio-ext-tiff</artifactId>
-            <!-- This seemed latest version 1.3.2: https://github.com/geosolutions-it/imageio-ext 2023 -->
+            <!-- Delay upgrading to 1.4.x or 2.x.x until 
+                 https://github.com/geosolutions-it/imageio-ext/issues/346 is resolved 
+                 and we can verify that https://github.com/cantaloupe-project/cantaloupe/issues/879 
+                 is solved under those versions
+                 -->
             <version>1.3.2</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,8 @@
         <dependency>
             <groupId>it.geosolutions.imageio-ext</groupId>
             <artifactId>imageio-ext-tiff</artifactId>
-            <version>1.4.14</version>
+            <!-- This seemed latest version 1.3.2: https://github.com/geosolutions-it/imageio-ext 2023 -->
+            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
Reverts cantaloupe-project/cantaloupe#809. See #879 

Gist is: imageio-ext-tiff 14+ (and still an issue in 2.x) introduced changes in the way the LZW decompressing is happening. Until we figure out an alternative or it gets fixed upstream, staying at 13 seems to be the safest path

@jcoyne @glenrobson please merge at your discretion, thanks