### PR TITLE
Fix flaky tests by downgrading JUnit and adding retry mechanism

### DIFF
--- a/ci.log
+++ b/ci.log
@@ -1,0 +1,3110 @@
+[Upload Release Asset/Upload Release Asset] ⭐ Run Set up job
+[Upload Release Asset/Upload Release Asset] 🚀  Start image=catthehacker/ubuntu:act-latest
+[CI/build-1                               ] ⭐ Run Set up job
+[CI/build-1                               ] 🚀  Start image=catthehacker/ubuntu:act-latest
+[CI/build-4                               ] ⭐ Run Set up job
+[CI/build-4                               ] 🚀  Start image=catthehacker/ubuntu:act-latest
+[CI/build-3                               ] ⭐ Run Set up job
+[CI/build-3                               ] 🚀  Start image=catthehacker/ubuntu:act-22.04
+[CI/build-2                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-5                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-6                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-7                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-8                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-9                               ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-10                              ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-11                              ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[CI/build-12                              ] 🚧  Skipping unsupported platform -- Try running with `-P windows-latest=...`
+[Upload Release Asset/Upload Release Asset]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
+[CI/build-1                               ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
+[CI/build-4                               ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
+[CI/build-3                               ]   🐳  docker pull image=catthehacker/ubuntu:act-22.04 platform= username= forcePull=true
+[CI/build-3                               ]   🐳  docker create image=catthehacker/ubuntu:act-22.04 platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-3                               ]   🐳  docker run image=catthehacker/ubuntu:act-22.04 platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[Upload Release Asset/Upload Release Asset]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-1                               ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-4                               ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-1                               ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[Upload Release Asset/Upload Release Asset]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-4                               ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
+[CI/build-3                               ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
+[CI/build-3                               ]   ✅  Success - Set up job
+[CI/build-4                               ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
+[CI/build-3                               ] 🧪  Matrix: map[java:jdk17 os:ubuntu-22.04]
+[Upload Release Asset/Upload Release Asset]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
+[CI/build-1                               ]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
+[CI/build-3                               ] ⭐ Run Main Check out the repository
+[CI/build-3                               ]   🐳  docker cp src=/home/okagen/study/cantaloupe/. dst=/home/okagen/study/cantaloupe
+[CI/build-4                               ]   ✅  Success - Set up job
+[Upload Release Asset/Upload Release Asset]   ✅  Success - Set up job
+[CI/build-4                               ] 🧪  Matrix: map[java:jdk21 os:ubuntu-latest]
+[CI/build-1                               ]   ✅  Success - Set up job
+[Upload Release Asset/Upload Release Asset]   ☁  git clone 'https://github.com/actions/setup-java' # ref=v1
+[CI/build-1                               ] 🧪  Matrix: map[java:jdk17 os:ubuntu-latest]
+[CI/build-4                               ] ⭐ Run Main Check out the repository
+[CI/build-1                               ] ⭐ Run Main Check out the repository
+[CI/build-4                               ]   🐳  docker cp src=/home/okagen/study/cantaloupe/. dst=/home/okagen/study/cantaloupe
+[CI/build-1                               ]   🐳  docker cp src=/home/okagen/study/cantaloupe/. dst=/home/okagen/study/cantaloupe
+[CI/build-4                               ]   ✅  Success - Main Check out the repository [522.121525ms]
+[CI/build-1                               ]   ✅  Success - Main Check out the repository [537.669993ms]
+[CI/build-1                               ] ⭐ Run Main Test in Linux JDK 17 (LTS)
+[CI/build-4                               ] ⭐ Run Main Test in Linux JDK 21 (LTS)
+[CI/build-1                               ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/1] user= workdir=
+[CI/build-4                               ]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/3] user= workdir=
+[CI/build-3                               ]   ✅  Success - Main Check out the repository [797.410786ms]
+[Upload Release Asset/Upload Release Asset]   ☁  git clone 'https://github.com/actions/create-release' # ref=v1.0.0
+[CI/build-3                               ] ⭐ Run Complete job
+[CI/build-3                               ] Cleaning up container for job build
+[CI/build-1                               ]   | #1 [internal] load local bake definitions
+[CI/build-4                               ]   | #1 [internal] load local bake definitions
+[CI/build-1                               ]   | #1 reading from stdin 554B done
+[CI/build-1                               ]   | #1 DONE 0.0s
+[CI/build-4                               ]   | #1 reading from stdin 554B done
+[CI/build-4                               ]   | #1 DONE 0.0s
+[Upload Release Asset/Upload Release Asset]   ☁  git clone 'https://github.com/actions/upload-release-asset' # ref=v1.0.1
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #2 [internal] load build definition from Dockerfile
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #2 [internal] load build definition from Dockerfile
+[CI/build-1                               ]   | #2 transferring dockerfile:
+[CI/build-4                               ]   | #2 transferring dockerfile:
+[CI/build-1                               ]   | #2 transferring dockerfile: 1.40kB done
+[CI/build-1                               ]   | #2 DONE 0.3s
+[CI/build-4                               ]   | #2 transferring dockerfile: 1.40kB done
+[CI/build-4                               ]   | #2 DONE 0.4s
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #3 [internal] load metadata for docker.io/library/ubuntu:noble
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #3 [internal] load metadata for docker.io/library/ubuntu:noble
+[CI/build-3                               ]   ✅  Success - Complete job
+[CI/build-3                               ] 🏁  Job succeeded
+[Upload Release Asset/Upload Release Asset] ⭐ Run Main actions/setup-java@v1
+[Upload Release Asset/Upload Release Asset]   🐳  docker cp src=/home/okagen/.cache/act/actions-setup-java@v1/ dst=/var/run/act/actions/actions-setup-java@v1/
+[CI/build-1                               ]   | #3 DONE 0.5s
+[CI/build-4                               ]   | #3 DONE 0.4s
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #4 [internal] load .dockerignore
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #4 [internal] load .dockerignore
+[CI/build-4                               ]   | #4 transferring context:
+[Upload Release Asset/Upload Release Asset]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.8/x64/bin/node /var/run/act/actions/actions-setup-java@v1/dist/setup/index.js] user= workdir=
+[Upload Release Asset/Upload Release Asset]   ❓ add-matcher /run/act/actions/actions-setup-java@v1/.github/java.json
+[Upload Release Asset/Upload Release Asset]   | creating settings.xml with server-id: github; environment variables: username=$GITHUB_ACTOR, password=$GITHUB_TOKEN, and gpg-passphrase=null
+[CI/build-4                               ]   | #4 transferring context: 2B done
+[Upload Release Asset/Upload Release Asset]   | writing /root/.m2/settings.xml
+[Upload Release Asset/Upload Release Asset]   ✅  Success - Main actions/setup-java@v1 [475.398463ms]
+[Upload Release Asset/Upload Release Asset]   ⚙  ::set-env:: JAVA_HOME=/opt/hostedtoolcache/jdk/17.0.17/x64
+[Upload Release Asset/Upload Release Asset]   ⚙  ::set-env:: JAVA_HOME_17_X64=/opt/hostedtoolcache/jdk/17.0.17/x64
+[Upload Release Asset/Upload Release Asset]   ⚙  ::set-env:: JAVA_HOME_17_x64=/opt/hostedtoolcache/jdk/17.0.17/x64
+[Upload Release Asset/Upload Release Asset]   ⚙  ::set-output:: path=/opt/hostedtoolcache/jdk/17.0.17/x64
+[Upload Release Asset/Upload Release Asset]   ⚙  ::set-output:: version=17
+[Upload Release Asset/Upload Release Asset]   ⚙  ::add-path:: /opt/hostedtoolcache/jdk/17.0.17/x64/bin
+[CI/build-1                               ]   | #4 transferring context:
+[CI/build-4                               ]   | #4 DONE 0.5s
+[Upload Release Asset/Upload Release Asset] ⭐ Run Main Checkout Code
+[Upload Release Asset/Upload Release Asset]   🐳  docker cp src=/home/okagen/study/cantaloupe/. dst=/home/okagen/study/cantaloupe
+[CI/build-1                               ]   | #4 transferring context: 2B done
+[CI/build-1                               ]   | #4 DONE 0.7s
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #5 [ 1/11] FROM docker.io/library/ubuntu:noble@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54
+[CI/build-4                               ]   | #5 DONE 0.0s
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #6 [internal] load build context
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #5 [ 1/11] FROM docker.io/library/ubuntu:noble@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54
+[CI/build-1                               ]   | #5 DONE 0.0s
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #6 [internal] load build context
+[CI/build-4                               ]   | #6 transferring context: 24.17MB 0.4s done
+[Upload Release Asset/Upload Release Asset]   ✅  Success - Main Checkout Code [722.272789ms]
+[Upload Release Asset/Upload Release Asset] ⭐ Run Main Build Project
+[CI/build-4                               ]   | #6 DONE 0.6s
+[Upload Release Asset/Upload Release Asset]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/2] user= workdir=
+[CI/build-1                               ]   | #6 transferring context: 24.17MB 0.4s done
+[Upload Release Asset/Upload Release Asset]   | /var/run/act/workflow/2: line 2: mvn: command not found
+[Upload Release Asset/Upload Release Asset]   ❌  Failure - Main Build Project [113.434162ms]
+[Upload Release Asset/Upload Release Asset] exitcode '127': command not found, please refer to https://github.com/nektos/act/issues/107 for more information
+[CI/build-1                               ]   | #6 DONE 0.8s
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #7 [ 2/11] RUN apt-get update && apt-get install -y --no-install-recommends   ca-certificates   ffmpeg   wget   libopenjp2-tools   liblcms2-dev   libpng-dev   libzstd-dev   libtiff-dev   libjpeg-dev   zlib1g-dev   libwebp-dev   libimage-exiftool-perl   libgrokj2k1   grokj2k-tools   adduser   openjdk-21-jdk   libturbojpeg   libturbojpeg-dev   maven   && rm -rf /var/lib/apt/lists/*
+[CI/build-4                               ]   | #7 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #8 [ 6/11] WORKDIR /home/cantaloupe
+[CI/build-4                               ]   | #8 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #9 [ 7/11] COPY ./pom.xml pom.xml
+[CI/build-4                               ]   | #9 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #10 [ 8/11] RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))" > ~/.bashrc
+[CI/build-4                               ]   | #10 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #11 [ 9/11] RUN mvn --quiet dependency:resolve
+[CI/build-4                               ]   | #11 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #12 [10/11] COPY --chown=cantaloupe docker/image_files/test.properties test.properties
+[CI/build-4                               ]   | #12 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #13 [ 5/11] RUN chown -R cantaloupe /home/cantaloupe
+[CI/build-4                               ]   | #13 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #14 [ 3/11] COPY dist/deps/Linux-x86-64/lib/* /usr/lib/
+[CI/build-4                               ]   | #14 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #15 [ 4/11] RUN adduser --home /home/cantaloupe cantaloupe
+[CI/build-4                               ]   | #15 CACHED
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #16 [11/11] COPY --chown=cantaloupe ./src src
+[CI/build-4                               ]   | #16 CACHED
+[Upload Release Asset/Upload Release Asset] ⭐ Run Post actions/setup-java@v1
+[Upload Release Asset/Upload Release Asset]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.8/x64/bin/node /var/run/act/actions/actions-setup-java@v1/dist/cleanup/index.js] user= workdir=
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #7 [ 2/11] RUN apt-get update && apt-get install -y --no-install-recommends   ca-certificates   ffmpeg   wget   libopenjp2-tools   liblcms2-dev   libpng-dev   libzstd-dev   libtiff-dev   libjpeg-dev   zlib1g-dev   libwebp-dev   libimage-exiftool-perl   libgrokj2k1   grokj2k-tools   adduser   openjdk-17-jdk   libturbojpeg   libturbojpeg-dev   maven   && rm -rf /var/lib/apt/lists/*
+[CI/build-1                               ]   | #7 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #8 [ 3/11] COPY dist/deps/Linux-x86-64/lib/* /usr/lib/
+[CI/build-1                               ]   | #8 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #9 [ 4/11] RUN adduser --home /home/cantaloupe cantaloupe
+[CI/build-1                               ]   | #9 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #10 [ 8/11] RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))" > ~/.bashrc
+[CI/build-1                               ]   | #10 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #11 [ 5/11] RUN chown -R cantaloupe /home/cantaloupe
+[CI/build-1                               ]   | #11 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #12 [ 6/11] WORKDIR /home/cantaloupe
+[CI/build-1                               ]   | #12 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #13 [ 7/11] COPY ./pom.xml pom.xml
+[CI/build-1                               ]   | #13 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #14 [ 9/11] RUN mvn --quiet dependency:resolve
+[CI/build-1                               ]   | #14 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #15 [10/11] COPY --chown=cantaloupe docker/image_files/test.properties test.properties
+[CI/build-1                               ]   | #15 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #16 [11/11] COPY --chown=cantaloupe ./src src
+[CI/build-1                               ]   | #16 CACHED
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #17 exporting to image
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #17 exporting to image
+[CI/build-4                               ]   | #17 exporting layers done
+[CI/build-4                               ]   | #17 writing image sha256:89743a55debadcf41023395505e813b5fc1777a39b5f0f60b46848dc1ef320f6 0.0s done
+[CI/build-4                               ]   | #17 naming to docker.io/library/linux-jdk21-cantaloupe 0.0s done
+[CI/build-4                               ]   | #17 DONE 0.1s
+[Upload Release Asset/Upload Release Asset]   ✅  Success - Post actions/setup-java@v1 [162.899954ms]
+[Upload Release Asset/Upload Release Asset] ⭐ Run Complete job
+[Upload Release Asset/Upload Release Asset]   ✅  Success - Complete job
+[Upload Release Asset/Upload Release Asset] 🏁  Job failed
+[CI/build-1                               ]   | #17 exporting layers done
+[CI/build-1                               ]   | #17 writing image sha256:f0b33586252c85ab344eb7a9b767209dab0f1d33eb8c9062d5c76c299cdeb4c3 0.0s done
+[CI/build-1                               ]   | #17 naming to docker.io/library/linux-jdk17-cantaloupe 0.0s done
+[CI/build-1                               ]   | #17 DONE 0.1s
+[CI/build-4                               ]   | 
+[CI/build-4                               ]   | #18 resolving provenance for metadata file
+[CI/build-1                               ]   | 
+[CI/build-1                               ]   | #18 resolving provenance for metadata file
+[CI/build-4                               ]   | #18 DONE 0.0s
+[CI/build-4                               ]   |  linux-jdk21-cantaloupe  Built
+[CI/build-4                               ]   |  Container linux-jdk21-redis-1  Running
+[CI/build-4                               ]   |  Container linux-jdk21-cantaloupe-1  Running
+[CI/build-4                               ]   |  Container linux-jdk21-minio-1  Running
+[CI/build-4                               ]   | Attaching to cantaloupe-1, minio-1, redis-1
+[CI/build-1                               ]   | #18 DONE 0.0s
+[CI/build-1                               ]   |  linux-jdk17-cantaloupe  Built
+[CI/build-1                               ]   |  Container linux-jdk17-redis-1  Running
+[CI/build-1                               ]   |  Container linux-jdk17-minio-1  Running
+[CI/build-1                               ]   |  Container linux-jdk17-cantaloupe-1  Stopping
+[CI/build-1                               ]   |  Container linux-jdk17-cantaloupe-1  Stopped
+[CI/build-1                               ]   |  Container linux-jdk17-cantaloupe-1  Removing
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] -------------< edu.illinois.library.cantaloupe:cantaloupe >-------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Building Cantaloupe 6.0-SNAPSHOT
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --------------------------------[ jar ]---------------------------------
+[CI/build-1                               ]   |  Container linux-jdk17-cantaloupe-1  Removed
+[CI/build-1                               ]   | Attaching to 00f9504640d2_linux-jdk17-cantaloupe-1, minio-1, redis-1
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Scanning for projects...
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] -------------< edu.illinois.library.cantaloupe:cantaloupe >-------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Building Cantaloupe 6.0-SNAPSHOT
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --------------------------------[ jar ]---------------------------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom (6.7 kB at 11 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom (1.9 kB at 29 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom (1.7 kB at 20 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom (2.0 kB at 24 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom (1.3 kB at 13 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom (3.3 kB at 28 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom (17 kB at 147 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom (5.8 kB at 44 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom (889 B at 9.6 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom (2.9 kB at 37 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom (3.0 kB at 42 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom (5.0 kB at 31 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom (890 B at 7.7 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom (2.8 kB at 23 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar (13 kB at 50 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar (35 kB at 121 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar (57 kB at 182 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar (29 kB at 83 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar (116 kB at 322 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar (21 kB at 51 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar (9.9 kB at 23 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar (152 kB at 336 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar (5.9 kB at 12 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar (24 kB at 49 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar (14 kB at 27 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom (6.7 kB at 8.3 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar (37 kB at 69 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar (87 kB at 160 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar (49 kB at 83 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar (10 kB at 17 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar (43 kB at 66 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar (86 kB at 131 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar (223 kB at 332 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom (1.9 kB at 17 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar (6.8 kB at 9.7 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar (61 kB at 86 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom (1.7 kB at 14 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Using 'UTF-8' encoding to copy filtered resources.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Copying 20 resources
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom (2.0 kB at 26 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom (2.3 kB at 32 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom (1.3 kB at 19 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom (22 kB at 296 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom (3.3 kB at 48 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom (3.9 kB at 57 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom (17 kB at 186 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom (3.3 kB at 42 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom (5.8 kB at 55 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom (1.9 kB at 21 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom (889 B at 8.8 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom (5.4 kB at 53 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom (2.9 kB at 23 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom (3.1 kB at 30 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom (3.0 kB at 28 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom (2.6 kB at 23 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom (1.2 kB at 12 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom (5.0 kB at 29 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom (7.8 kB at 74 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom (890 B at 8.2 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom (11 kB at 92 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom (2.8 kB at 27 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom (770 B at 9.4 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar (13 kB at 171 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom (5.0 kB at 65 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar (29 kB at 207 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar (57 kB at 401 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar (35 kB at 216 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom (22 kB at 307 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar (152 kB at 866 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar (116 kB at 638 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar (9.9 kB at 48 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar (21 kB at 93 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom (4.0 kB at 56 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar (14 kB at 56 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar (5.9 kB at 23 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar (24 kB at 92 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar (37 kB at 129 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom (5.5 kB at 66 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar (49 kB at 147 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar (87 kB at 259 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar (86 kB at 241 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar (10 kB at 28 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar (223 kB at 565 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom (11 kB at 112 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar (6.8 kB at 16 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar (43 kB at 97 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar (61 kB at 128 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom (6.6 kB at 76 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Using 'UTF-8' encoding to copy filtered resources.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Copying 20 resources
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom (1.9 kB at 22 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ cantaloupe ---
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom (2.2 kB at 23 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.pom (2.3 kB at 22 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom (910 B at 11 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/3.0/maven-3.0.pom (22 kB at 184 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom (5.4 kB at 69 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.pom (3.9 kB at 31 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom (3.0 kB at 26 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.pom (3.3 kB at 30 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom (6.8 kB at 62 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.pom (1.9 kB at 20 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom (8.4 kB at 95 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.pom (5.4 kB at 58 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom (5.1 kB at 53 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom (2.1 kB at 23 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-plexus/1.4.2/guice-plexus-1.4.2.pom (3.1 kB at 24 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom (1.9 kB at 22 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/inject/guice-bean/1.4.2/guice-bean-1.4.2.pom (2.6 kB at 30 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom (2.2 kB at 31 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject/1.4.2/sisu-inject-1.4.2.pom (1.2 kB at 18 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom (2.5 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-parent/1.4.2/sisu-parent-1.4.2.pom (7.8 kB at 95 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom (1.7 kB at 21 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/6/forge-parent-6.pom (11 kB at 136 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom (7.7 kB at 95 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom (770 B at 8.6 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom (2.1 kB at 33 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom (5.0 kB at 61 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom (3.7 kB at 52 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/4.0/plexus-4.0.pom (22 kB at 299 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom (1.7 kB at 31 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.pom (4.0 kB at 53 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom (5.6 kB at 66 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.pom (5.5 kB at 72 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom (4.6 kB at 54 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7.pom (11 kB at 137 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom (41 kB at 454 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.pom (6.6 kB at 74 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom (13 kB at 112 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.pom (1.9 kB at 14 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom (4.7 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.pom (2.2 kB at 23 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom (1.5 kB at 15 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.pom (910 B at 12 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom (22 kB at 270 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.18/plexus-components-1.1.18.pom (5.4 kB at 66 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom (12 kB at 138 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom (3.0 kB at 31 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom (2.2 kB at 24 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom (6.8 kB at 70 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom (3.2 kB at 27 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom (8.4 kB at 72 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom (2.0 kB at 22 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom (5.1 kB at 56 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom (1.9 kB at 21 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom (2.1 kB at 25 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom (7.9 kB at 93 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.pom (1.9 kB at 21 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom (3.0 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.pom (2.2 kB at 24 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom (2.2 kB at 30 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.pom (2.5 kB at 34 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom (2.2 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.pom (1.7 kB at 24 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom (1.6 kB at 27 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom (1.9 kB at 27 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-parent/1.7/aether-parent-1.7.pom (7.7 kB at 80 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom (1.7 kB at 25 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.pom (2.1 kB at 23 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom (2.8 kB at 26 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.pom (3.7 kB at 32 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom (3.1 kB at 28 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.pom (1.7 kB at 14 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom (1.9 kB at 16 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.pom (5.6 kB at 45 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom (2.1 kB at 14 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/30/maven-shared-components-30.pom (4.6 kB at 36 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom (1.3 kB at 16 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/30/maven-parent-30.pom (41 kB at 475 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom (4.0 kB at 55 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.pom (13 kB at 155 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom (4.9 kB at 67 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom (4.7 kB at 51 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom (965 B at 8.0 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom (1.5 kB at 15 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom (5.1 kB at 45 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom (22 kB at 161 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom (4.1 kB at 33 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom (12 kB at 95 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom (2.9 kB at 19 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom (2.2 kB at 17 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom (11 kB at 99 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom (3.2 kB at 33 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom (16 kB at 154 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom (2.0 kB at 19 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom (867 B at 10 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom (1.9 kB at 23 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom (6.0 kB at 85 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom (7.9 kB at 98 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom (2.7 kB at 35 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom (3.0 kB at 30 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom (3.8 kB at 39 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom (2.2 kB at 19 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom (20 kB at 193 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom (2.2 kB at 22 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom (692 B at 7.5 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom (1.6 kB at 20 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom (771 B at 8.3 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom (1.9 kB at 17 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom (1.3 kB at 12 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom (1.7 kB at 13 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar (49 kB at 371 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar (153 kB at 1.0 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar (165 kB at 1.0 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar (472 kB at 2.2 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar (202 kB at 885 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom (2.8 kB at 20 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar (52 kB at 204 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar (222 kB at 796 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar (47 kB at 138 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar (527 kB at 1.5 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar (38 kB at 106 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar (30 kB at 84 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom (3.1 kB at 28 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar (148 kB at 384 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar (74 kB at 163 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar (51 kB at 112 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar (106 kB at 225 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom (1.9 kB at 16 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar (108 kB at 215 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar (14 kB at 26 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar (61 kB at 108 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar (46 kB at 80 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar (4.3 kB at 7.2 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar (29 kB at 47 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom (2.1 kB at 17 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar (13 kB at 20 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar (167 kB at 232 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar (39 kB at 54 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar (209 kB at 284 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar (14 kB at 18 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom (1.3 kB at 9.2 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.jar (111 kB at 131 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar (27 kB at 32 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar (4.7 kB at 5.5 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar (317 kB at 367 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar (21 kB at 24 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom (4.0 kB at 37 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom (4.9 kB at 40 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Compiling 581 source files to /home/cantaloupe/target/classes
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom (965 B at 6.7 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom (5.1 kB at 45 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom (4.1 kB at 42 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom (2.9 kB at 20 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5/ow2-1.5.pom (11 kB at 97 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.pom (16 kB at 236 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.pom (867 B at 13 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.8.4/plexus-compiler-2.8.4.pom (6.0 kB at 89 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/4.0/plexus-components-4.0.pom (2.7 kB at 27 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.pom (3.8 kB at 33 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom (20 kB at 168 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.pom (692 B at 6.1 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.pom (771 B at 6.9 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom (1.3 kB at 13 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/3.0/maven-model-3.0.jar (165 kB at 1.3 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/3.0/maven-plugin-api-3.0.jar (49 kB at 373 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-plexus/1.4.2/sisu-inject-plexus-1.4.2.jar (202 kB at 1.5 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-inject-bean/1.4.2/sisu-inject-bean-1.4.2.jar (153 kB at 1.1 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/sisu/sisu-guice/2.1.7/sisu-guice-2.1.7-noaop.jar (472 kB at 2.3 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/3.0/maven-artifact-3.0.jar (52 kB at 222 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.4/plexus-utils-2.0.4.jar (222 kB at 885 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/3.0/maven-settings-3.0.jar (47 kB at 179 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/3.0/maven-core-3.0.jar (527 kB at 1.8 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings-builder/3.0/maven-settings-builder-3.0.jar (38 kB at 118 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/3.0/maven-repository-metadata-3.0.jar (30 kB at 88 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-aether-provider/3.0/maven-aether-provider-3.0.jar (51 kB at 138 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-model-builder/3.0/maven-model-builder-3.0.jar (148 kB at 381 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-impl/1.7/aether-impl-1.7.jar (106 kB at 235 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-spi/1.7/aether-spi-1.7.jar (14 kB at 29 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-api/1.7/aether-api-1.7.jar (74 kB at 155 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar (61 kB at 117 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/aether/aether-util/1.7/aether-util-1.7.jar (108 kB at 204 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.3/plexus-classworlds-2.2.3.jar (46 kB at 81 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar (29 kB at 50 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar (4.3 kB at 7.4 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar (13 kB at 22 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar (167 kB at 267 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar (14 kB at 20 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/commons-io/commons-io/2.5/commons-io-2.5.jar (209 kB at 301 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.jar (39 kB at 56 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.jar (111 kB at 151 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.0-M9/qdox-2.0-M9.jar (317 kB at 416 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.8.4/plexus-compiler-api-2.8.4.jar (27 kB at 35 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.8.4/plexus-compiler-manager-2.8.4.jar (4.7 kB at 5.9 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.8.4/plexus-compiler-javac-2.8.4.jar (21 kB at 26 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Compiling 581 source files to /home/cantaloupe/target/classes
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java: Some input files use or override a deprecated API.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java: Recompile with -Xlint:deprecation for details.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/kdu_jni/Kdu_compressed_source.java: Some input files use or override a deprecated API that is marked for removal.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/kdu_jni/Kdu_compressed_source.java: Recompile with -Xlint:removal for details.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java: Some input files use unchecked or unsafe operations.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java: Recompile with -Xlint:unchecked for details.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Using 'UTF-8' encoding to copy filtered resources.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Copying 141 resources
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Compiling 313 source files to /home/cantaloupe/target/test-classes
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java: Some input files use or override a deprecated API.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/processor/ProcessorFactory.java: Recompile with -Xlint:deprecation for details.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java: Some input files use unchecked or unsafe operations.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java: Recompile with -Xlint:unchecked for details.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ cantaloupe ---
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Using 'UTF-8' encoding to copy filtered resources.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Copying 141 resources
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ cantaloupe ---
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Compiling 313 source files to /home/cantaloupe/target/test-classes
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/processor/AbstractProcessorTest.java: Some input files use or override a deprecated API.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/processor/AbstractProcessorTest.java: Recompile with -Xlint:deprecation for details.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextMapTest.java: Some input files use unchecked or unsafe operations.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextMapTest.java: Recompile with -Xlint:unchecked for details.
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] --- maven-surefire-plugin:3.5.3:test (default-test) @ cantaloupe ---
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.pom (3.7 kB at 31 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.pom (3.5 kB at 39 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.pom (4.0 kB at 39 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.pom (3.6 kB at 40 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.pom (7.8 kB at 86 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.pom (5.0 kB at 39 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.pom (1.7 kB at 14 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.pom (5.4 kB at 33 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/42/maven-shared-components-42.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/42/maven-shared-components-42.pom (3.8 kB at 29 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom (50 kB at 193 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom (24 kB at 146 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.pom (4.1 kB at 32 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.4.0/plexus-languages-1.4.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.4.0/plexus-languages-1.4.0.pom (3.9 kB at 32 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom (29 kB at 256 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.pom (2.4 kB at 26 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.pom (18 kB at 163 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.jar (14 kB at 145 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.jar (26 kB at 240 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.jar (172 kB at 1.5 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.jar (312 kB at 1.7 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.jar (118 kB at 550 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.jar (8.2 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.jar (2.9 MB at 12 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar (58 kB at 250 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.jar (57 kB at 177 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar (126 kB at 378 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar (353 kB at 992 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar (169 kB at 470 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/processor/AbstractProcessorTest.java: Some input files use or override a deprecated API.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/processor/AbstractProcessorTest.java: Recompile with -Xlint:deprecation for details.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextMapTest.java: Some input files use unchecked or unsafe operations.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] /home/cantaloupe/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextMapTest.java: Recompile with -Xlint:unchecked for details.
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] --- maven-surefire-plugin:3.5.3:test (default-test) @ cantaloupe ---
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests will run in random order. To reproduce ordering use flag -Dsurefire.runOrder.random.seed=11041930180283935
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.pom (3.7 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.pom (5.2 kB at 64 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.5.3/surefire-providers-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.pom (3.5 kB at 35 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.5.3/surefire-providers-3.5.3.pom (2.5 kB at 31 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.pom (4.0 kB at 47 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.pom (3.6 kB at 46 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.pom (3.1 kB at 36 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.pom (7.8 kB at 90 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.pom (3.2 kB at 19 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.pom (5.0 kB at 51 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.pom (2.8 kB at 24 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.pom (1.7 kB at 18 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.pom (3.0 kB at 25 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.pom (5.4 kB at 42 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/42/maven-shared-components-42.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.jar (18 kB at 241 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.jar (27 kB at 337 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.jar (208 kB at 2.2 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/42/maven-shared-components-42.pom (3.8 kB at 45 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.jar (256 kB at 2.0 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar (152 kB at 1.2 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from osgeo: https://repo.osgeo.org/repository/release/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/42/maven-parent-42.pom (50 kB at 587 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/32/apache-32.pom (24 kB at 310 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.pom (4.1 kB at 40 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.4.0/plexus-languages-1.4.0.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.4.0/plexus-languages-1.4.0.pom (3.9 kB at 31 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom (29 kB at 270 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.pom (2.4 kB at 20 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom (3.0 kB at 27 kB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from osgeo: https://repo.osgeo.org/repository/release/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.pom (18 kB at 151 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.5.3/surefire-extensions-api-3.5.3.jar (26 kB at 220 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.5.3/surefire-api-3.5.3.jar (172 kB at 1.4 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.5.3/maven-surefire-common-3.5.3.jar (312 kB at 2.5 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.5.3/surefire-logger-api-3.5.3.jar (14 kB at 70 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.jar
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar (189 kB at 1.4 MB/s)
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] -------------------------------------------------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO]  T E S T S
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] -------------------------------------------------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.5.3/surefire-shared-utils-3.5.3.jar (2.9 MB at 13 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.5.3/surefire-booter-3.5.3.jar (118 kB at 492 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/3.4.0/maven-common-artifact-filters-3.4.0.jar (58 kB at 235 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.5.3/surefire-extensions-spi-3.5.3.jar (8.2 kB at 32 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.4.0/plexus-java-1.4.0.jar (57 kB at 190 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.7.1/asm-9.7.1.jar (126 kB at 398 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar (353 kB at 1.0 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar (169 kB at 478 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests will run in random order. To reproduce ordering use flag -Dsurefire.runOrder.random.seed=11041932245223959
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.pom (5.2 kB at 48 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.5.3/surefire-providers-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.5.3/surefire-providers-3.5.3.pom (2.5 kB at 22 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.pom (3.1 kB at 27 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.pom (3.2 kB at 14 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.pom (2.8 kB at 18 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.pom (3.0 kB at 18 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.5.3/common-java5-3.5.3.jar (18 kB at 138 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit-platform/3.5.3/surefire-junit-platform-3.5.3.jar (27 kB at 208 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.12.1/junit-platform-launcher-1.12.1.jar (208 kB at 1.5 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-commons/1.12.1/junit-platform-commons-1.12.1.jar (152 kB at 1.0 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-engine/1.12.1/junit-platform-engine-1.12.1.jar (256 kB at 1.6 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from osgeo: https://repo.osgeo.org/repository/release/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.RegionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.pom (3.0 kB at 25 kB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from osgeo: https://repo.osgeo.org/repository/release/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/platform/junit-platform-launcher/1.11.4/junit-platform-launcher-1.11.4.jar (189 kB at 2.4 MB/s)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] -------------------------------------------------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO]  T E S T S
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] -------------------------------------------------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.698 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.RationalTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.150 s -- in edu.illinois.library.cantaloupe.util.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.FieldTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.ArrayUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.750 s -- in edu.illinois.library.cantaloupe.image.exif.FieldTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.832 s -- in edu.illinois.library.cantaloupe.util.ArrayUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.SourceFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.771 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.JavaRequestContextTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.063 s -- in edu.illinois.library.cantaloupe.delegate.JavaRequestContextTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.ArrayUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.108 s -- in edu.illinois.library.cantaloupe.util.ArrayUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.300 s -- in edu.illinois.library.cantaloupe.source.SourceFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.AuditableFutureTaskTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.972 s -- in edu.illinois.library.cantaloupe.async.AuditableFutureTaskTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.178 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.847 s -- in edu.illinois.library.cantaloupe.image.exif.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.966 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.385 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheWorkerRunnerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.785 s -- in edu.illinois.library.cantaloupe.cache.CacheWorkerRunnerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.GrokProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 38, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.504 s -- in edu.illinois.library.cantaloupe.processor.GrokProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.ScaleConstraintTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.791 s -- in edu.illinois.library.cantaloupe.image.ScaleConstraintTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.redaction.RedactionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.588 s -- in edu.illinois.library.cantaloupe.operation.redaction.RedactionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.health.HealthResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.545 s -- in edu.illinois.library.cantaloupe.resource.health.HealthResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoRestrictiveBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.578 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoRestrictiveBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.973 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RouteTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.551 s -- in edu.illinois.library.cantaloupe.resource.RouteTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.647 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 57, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.25 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.982 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.RangeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.751 s -- in edu.illinois.library.cantaloupe.http.RangeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.HeaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.962 s -- in edu.illinois.library.cantaloupe.http.HeaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.TagSetTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.058 s -- in edu.illinois.library.cantaloupe.image.exif.TagSetTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SourceFormatExceptionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.281 s -- in edu.illinois.library.cantaloupe.processor.SourceFormatExceptionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.PdfBoxProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 41, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.759 s -- in edu.illinois.library.cantaloupe.processor.PdfBoxProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.SocketUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.87 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_0ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.IdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.142 s -- in edu.illinois.library.cantaloupe.util.SocketUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.611 s -- in edu.illinois.library.cantaloupe.image.IdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheWorkerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.850 s -- in edu.illinois.library.cantaloupe.cache.CacheWorkerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.CookiesTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.872 s -- in edu.illinois.library.cantaloupe.http.CookiesTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.FileServletTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.152 s -- in edu.illinois.library.cantaloupe.resource.FileServletTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.AdminResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.145 s -- in edu.illinois.library.cantaloupe.resource.admin.AdminResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.BufferedImageSequenceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.561 s -- in edu.illinois.library.cantaloupe.processor.codec.BufferedImageSequenceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.JavaRequestContextTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.859 s -- in edu.illinois.library.cantaloupe.delegate.JavaRequestContextTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.769 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.008 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.RectangleTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.699 s -- in edu.illinois.library.cantaloupe.image.RectangleTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.707 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ResponseTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.103 s -- in edu.illinois.library.cantaloupe.http.ResponseTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.FormatTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.646 s -- in edu.illinois.library.cantaloupe.image.FormatTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.ConfigurationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.989 s -- in edu.illinois.library.cantaloupe.resource.admin.ConfigurationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.30 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.RasterizationHelperTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.649 s -- in edu.illinois.library.cantaloupe.processor.RasterizationHelperTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3HTTPImageInputStreamClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 82, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.171 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextDecoratorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.511 s -- in edu.illinois.library.cantaloupe.resource.RequestContextDecoratorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HTTPRequestInfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.541 s -- in edu.illinois.library.cantaloupe.source.HTTPRequestInfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.094 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.873 s -- in edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.35 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.JRubyDelegateProxyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.994 s -- in edu.illinois.library.cantaloupe.delegate.JRubyDelegateProxyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.025 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.RangeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.544 s -- in edu.illinois.library.cantaloupe.http.RangeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.079 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.redaction.RedactionServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.827 s -- in edu.illinois.library.cantaloupe.operation.redaction.RedactionServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ProcessorFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.583 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ProcessorFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.539 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 55.95 s -- in edu.illinois.library.cantaloupe.source.S3HTTPImageInputStreamClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RouteTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.602 s -- in edu.illinois.library.cantaloupe.resource.RouteTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s -- in edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 61, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.110 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.CommandLocatorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.047 s -- in edu.illinois.library.cantaloupe.util.CommandLocatorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.stream.ClosingMemoryCacheImageInputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.922 s -- in edu.illinois.library.cantaloupe.source.stream.ClosingMemoryCacheImageInputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 57, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.14 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.xmp.UtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.568 s -- in edu.illinois.library.cantaloupe.image.xmp.UtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000MetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.743 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000MetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ReferenceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.754 s -- in edu.illinois.library.cantaloupe.http.ReferenceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 77, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.74 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.993 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.626 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.AbstractResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.934 s -- in edu.illinois.library.cantaloupe.resource.AbstractResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.InformationFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.084 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.InformationFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPS2Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.616 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPS2Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.416 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.89 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.585 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.952 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.221 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.StopwatchTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.518 s -- in edu.illinois.library.cantaloupe.util.StopwatchTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.S3CacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.06 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.IncompatibleSourceExceptionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 s -- in edu.illinois.library.cantaloupe.processor.IncompatibleSourceExceptionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.SystemUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.287 s -- in edu.illinois.library.cantaloupe.util.SystemUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.NameFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.938 s -- in edu.illinois.library.cantaloupe.source.NameFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.DirectoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.843 s -- in edu.illinois.library.cantaloupe.image.exif.DirectoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextMapTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.756 s -- in edu.illinois.library.cantaloupe.resource.RequestContextMapTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.DelegateAuthorizerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.149 s -- in edu.illinois.library.cantaloupe.auth.DelegateAuthorizerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.733 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.515 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheWorkerRunnerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.540 s -- in edu.illinois.library.cantaloupe.cache.CacheWorkerRunnerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.510 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.981 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextDecoratorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.487 s -- in edu.illinois.library.cantaloupe.resource.RequestContextDecoratorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ReferenceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 51, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.660 s -- in edu.illinois.library.cantaloupe.http.ReferenceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.IdentifierFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.664 s -- in edu.illinois.library.cantaloupe.source.IdentifierFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ParametersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.672 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ParametersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.JaiProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 40, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.387 s -- in edu.illinois.library.cantaloupe.processor.JaiProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.Java2dProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 41, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4.642 s -- in edu.illinois.library.cantaloupe.processor.Java2dProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.PropertiesDocumentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.569 s -- in edu.illinois.library.cantaloupe.config.PropertiesDocumentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3StreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 74.27 s -- in edu.illinois.library.cantaloupe.cache.S3CacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MediaTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | detection failed: [format: webm] [file: webm]
+[CI/build-4                               ]   | cantaloupe-1  | detection failed:	format: webm	file: webm
+[CI/build-4                               ]   | cantaloupe-1  | detection failed:	format: webm	file: webm
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.873 s -- in edu.illinois.library.cantaloupe.image.MediaTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.995 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.719 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.KeyValuePairTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.565 s -- in edu.illinois.library.cantaloupe.http.KeyValuePairTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.636 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.616 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 45, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.653 s -- in edu.illinois.library.cantaloupe.operation.CropByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.InfoCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.539 s -- in edu.illinois.library.cantaloupe.cache.InfoCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.602 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ProcessorFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.671 s -- in edu.illinois.library.cantaloupe.processor.ProcessorFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.stream.HTTPImageInputStreamTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.500 s -- in edu.illinois.library.cantaloupe.source.stream.HTTPImageInputStreamTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 35, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 26.19 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.TransposeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.549 s -- in edu.illinois.library.cantaloupe.operation.TransposeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HTTPStreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 1.117 s -- in edu.illinois.library.cantaloupe.source.HTTPStreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.PathStreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.542 s -- in edu.illinois.library.cantaloupe.source.PathStreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.DataTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.562 s -- in edu.illinois.library.cantaloupe.image.exif.DataTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.DelegateOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.839 s -- in edu.illinois.library.cantaloupe.operation.overlay.DelegateOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.HealthCheckerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.550 s -- in edu.illinois.library.cantaloupe.status.HealthCheckerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.FfmpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 75.91 s -- in edu.illinois.library.cantaloupe.source.S3StreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.health.HealthResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.096 s -- in edu.illinois.library.cantaloupe.resource.health.HealthResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.OutputFormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.852 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.OutputFormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.JRubyDelegateProxyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.078 s -- in edu.illinois.library.cantaloupe.delegate.JRubyDelegateProxyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.HealthTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 39, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 15.53 s -- in edu.illinois.library.cantaloupe.processor.FfmpegProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.ObjectCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.769 s -- in edu.illinois.library.cantaloupe.status.HealthTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.RasterizationHelperTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.746 s -- in edu.illinois.library.cantaloupe.util.ObjectCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.803 s -- in edu.illinois.library.cantaloupe.processor.RasterizationHelperTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.TrailingSlashRemovingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.795 s -- in edu.illinois.library.cantaloupe.resource.TrailingSlashRemovingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.TempFileDownloadTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.971 s -- in edu.illinois.library.cantaloupe.processor.TempFileDownloadTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.IdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.849 s -- in edu.illinois.library.cantaloupe.image.IdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.RetrievalStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.718 s -- in edu.illinois.library.cantaloupe.processor.RetrievalStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.ThreadPoolTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.734 s -- in edu.illinois.library.cantaloupe.async.ThreadPoolTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.106 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.stream.HTTPImageInputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.093 s -- in edu.illinois.library.cantaloupe.source.stream.HTTPImageInputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.S3MultipartAsyncOutputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.753 s -- in edu.illinois.library.cantaloupe.cache.S3MultipartAsyncOutputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.CookiesTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.729 s -- in edu.illinois.library.cantaloupe.http.CookiesTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.JdbcCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 30.31 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.TempFileDownloadTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.554 s -- in edu.illinois.library.cantaloupe.processor.TempFileDownloadTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.955 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ComplianceLevelTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.618 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ComplianceLevelTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.779 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.ConfigurationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 s -- in edu.illinois.library.cantaloupe.config.ConfigurationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.598 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.Version1_1ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.156 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.Version1_1ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.OrientationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.554 s -- in edu.illinois.library.cantaloupe.image.OrientationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.TurboJpegProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 38, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.376 s -- in edu.illinois.library.cantaloupe.processor.TurboJpegProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.JdbcCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 27, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 27.74 s -- in edu.illinois.library.cantaloupe.cache.JdbcCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.553 s -- in edu.illinois.library.cantaloupe.processor.SelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 27, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 26.64 s -- in edu.illinois.library.cantaloupe.cache.JdbcCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.573 s -- in edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.952 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TasksResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 56, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.34 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.TransposeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.107 s -- in edu.illinois.library.cantaloupe.operation.TransposeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000KakaduImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.022 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000KakaduImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.KakaduNativeProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.733 s -- in edu.illinois.library.cantaloupe.resource.api.TasksResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 39, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.568 s -- in edu.illinois.library.cantaloupe.processor.KakaduNativeProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTransformerFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.912 s -- in edu.illinois.library.cantaloupe.resource.RequestTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.FilesystemSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.294 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTransformerFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.OpenJpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.282 s -- in edu.illinois.library.cantaloupe.source.FilesystemSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 40, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 2.042 s -- in edu.illinois.library.cantaloupe.processor.OpenJpegProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.HeadersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000MetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.855 s -- in edu.illinois.library.cantaloupe.http.HeadersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.054 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000MetadataReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.DelegateProxyServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.xmp.UtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.758 s -- in edu.illinois.library.cantaloupe.image.xmp.UtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoBooleanBuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.805 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoBooleanBuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.AuditableFutureTaskTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.056 s -- in edu.illinois.library.cantaloupe.async.AuditableFutureTaskTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.267 s -- in edu.illinois.library.cantaloupe.delegate.DelegateProxyServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ColorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.861 s -- in edu.illinois.library.cantaloupe.operation.ColorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ColorTransformTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.772 s -- in edu.illinois.library.cantaloupe.operation.ColorTransformTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.826 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.292 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTransformerFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.157 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.80 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.TagSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.080 s -- in edu.illinois.library.cantaloupe.image.exif.TagSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.602 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTransformerFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.275 s -- in edu.illinois.library.cantaloupe.cache.CacheFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.ConfigurationProviderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.852 s -- in edu.illinois.library.cantaloupe.config.ConfigurationProviderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.339 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropToSquareTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.738 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.877 s -- in edu.illinois.library.cantaloupe.operation.CropToSquareTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthorizerFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.476 s -- in edu.illinois.library.cantaloupe.auth.AuthorizerFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.xmp.MapReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | ------ ELEMENTS -------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiAdrCity
+[CI/build-4                               ]   | cantaloupe-1  | Urbana
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiAdrCtry
+[CI/build-4                               ]   | cantaloupe-1  | United States
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiAdrExtadr
+[CI/build-4                               ]   | cantaloupe-1  | 1408 W. Gregory Drive
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiAdrPcode
+[CI/build-4                               ]   | cantaloupe-1  | 61801
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiAdrRegion
+[CI/build-4                               ]   | cantaloupe-1  | Illinois
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiEmailWork
+[CI/build-4                               ]   | cantaloupe-1  | dcc@library.illinois.edu
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiTelWork
+[CI/build-4                               ]   | cantaloupe-1  | +1+1(217)2442062
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:CiUrlWork
+[CI/build-4                               ]   | cantaloupe-1  | http://www.library.illinois.edu/dcc/
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | Iptc4xmpCore:SubjectCode
+[CI/build-4                               ]   | cantaloupe-1  | [new subject code, Preservation Master creation]
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | dc:creator
+[CI/build-4                               ]   | cantaloupe-1  | University of Illinois Library
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | dc:title
+[CI/build-4                               ]   | cantaloupe-1  | Illini Union Photographs Record Series 3707005
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | exif:ExifVersion
+[CI/build-4                               ]   | cantaloupe-1  | 0221
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | exif:Firmware
+[CI/build-4                               ]   | cantaloupe-1  | P40+-M, Firmware: Main=5.1.8, Boot=2.3, FPGA=1.2.4, CPLD=5.0.1, PAVR=1.0.3, UIFC=1.0.1, TGEN=1.0
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | exif:SerialNumber
+[CI/build-4                               ]   | cantaloupe-1  | EG031306
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | photoshop:Credit
+[CI/build-4                               ]   | cantaloupe-1  | JP Goguen
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | photoshop:DateCreated
+[CI/build-4                               ]   | cantaloupe-1  | 2012-10-03T14:25:41-05:00
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | photoshop:TransmissionReference
+[CI/build-4                               ]   | cantaloupe-1  | Access Jpeg
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | xmpRights:UsageTerms
+[CI/build-4                               ]   | cantaloupe-1  | No reproduction without prior permission
+[CI/build-4                               ]   | cantaloupe-1  | -------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.013 s -- in edu.illinois.library.cantaloupe.image.xmp.MapReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoBooleanBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.527 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoBooleanBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.ApplicationServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 2.657 s -- in edu.illinois.library.cantaloupe.ApplicationServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPS2Test
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.269 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPS2Test
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.CookieTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.541 s -- in edu.illinois.library.cantaloupe.http.CookieTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.OutputFormatTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.589 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.OutputFormatTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ServiceFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.555 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ServiceFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.SharpenTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.551 s -- in edu.illinois.library.cantaloupe.operation.SharpenTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 35, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 26.95 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.RedisCacheTest
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:44:26.116 * 100 changes in 300 seconds. Saving...
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:44:26.117 * Background saving started by pid 30
+[CI/build-1                               ]   | redis-1                                | 30:C 31 Dec 2025 07:44:26.126 * DB saved on disk
+[CI/build-1                               ]   | redis-1                                | 30:C 31 Dec 2025 07:44:26.127 * Fork CoW for RDB: current 0 MB, peak 0 MB, average 0 MB
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:44:26.219 * Background saving terminated with success
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 77, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 27.37 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.DelegateMetaIdentifierTransformerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.828 s -- in edu.illinois.library.cantaloupe.image.DelegateMetaIdentifierTransformerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.ApplicationStatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.582 s -- in edu.illinois.library.cantaloupe.status.ApplicationStatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.KakaduNativeProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 39, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.232 s -- in edu.illinois.library.cantaloupe.processor.KakaduNativeProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.Java2dProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 23, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 27.69 s -- in edu.illinois.library.cantaloupe.cache.RedisCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 1.677 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.JdbcSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 41, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 6.409 s -- in edu.illinois.library.cantaloupe.processor.Java2dProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.096 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.412 s -- in edu.illinois.library.cantaloupe.source.JdbcSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.114 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest$KeyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.731 s -- in edu.illinois.library.cantaloupe.cache.HeapCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.FeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TaskResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.768 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.FeatureTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.640 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.418 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.ApplicationStatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.477 s -- in edu.illinois.library.cantaloupe.resource.api.TaskResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.796 s -- in edu.illinois.library.cantaloupe.status.ApplicationStatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.JAIUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.288 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.490 s -- in edu.illinois.library.cantaloupe.processor.JAIUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.286 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.425 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.ConfigurationProviderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.823 s -- in edu.illinois.library.cantaloupe.config.ConfigurationProviderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ColorTransformTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.879 s -- in edu.illinois.library.cantaloupe.operation.ColorTransformTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.BasicStringOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.570 s -- in edu.illinois.library.cantaloupe.operation.overlay.BasicStringOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.EncodeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.193 s -- in edu.illinois.library.cantaloupe.operation.EncodeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TaskMonitorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.669 s -- in edu.illinois.library.cantaloupe.resource.api.TaskMonitorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.SocketUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.465 s -- in edu.illinois.library.cantaloupe.util.SocketUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.633 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.04 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.MapConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.AutomaticSelectionStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.974 s -- in edu.illinois.library.cantaloupe.config.MapConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.036 s -- in edu.illinois.library.cantaloupe.processor.AutomaticSelectionStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.IdentifierFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleByPercentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.938 s -- in edu.illinois.library.cantaloupe.source.IdentifierFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.924 s -- in edu.illinois.library.cantaloupe.operation.ScaleByPercentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TaskMonitorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.HeaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.789 s -- in edu.illinois.library.cantaloupe.resource.api.TaskMonitorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.806 s -- in edu.illinois.library.cantaloupe.http.HeaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.ImageInfoUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.AdminResourceUITest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.779 s -- in edu.illinois.library.cantaloupe.resource.iiif.ImageInfoUtilTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.738 s -- in edu.illinois.library.cantaloupe.image.MetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.FfmpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 39, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 15.63 s -- in edu.illinois.library.cantaloupe.processor.FfmpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.Java2DUtilTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 58, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.968 s -- in edu.illinois.library.cantaloupe.processor.Java2DUtilTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ProcessorFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.857 s -- in edu.illinois.library.cantaloupe.processor.ProcessorFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.OverlayFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.549 s -- in edu.illinois.library.cantaloupe.operation.overlay.OverlayFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPS1Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.883 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPS1Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.898 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 38.30 s -- in edu.illinois.library.cantaloupe.resource.admin.AdminResourceUITest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.217 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3SourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.S3CacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 31, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 73.75 s -- in edu.illinois.library.cantaloupe.cache.S3CacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.redaction.RedactionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.571 s -- in edu.illinois.library.cantaloupe.operation.redaction.RedactionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.ApplicationServerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 2.707 s -- in edu.illinois.library.cantaloupe.ApplicationServerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.EnvironmentConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.569 s -- in edu.illinois.library.cantaloupe.config.EnvironmentConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ProcessorFeatureTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.569 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ProcessorFeatureTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.HeritablePropertiesConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 114, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.681 s -- in edu.illinois.library.cantaloupe.config.HeritablePropertiesConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.RotationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.567 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.RotationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.OpenJpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 40, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.024 s -- in edu.illinois.library.cantaloupe.processor.OpenJpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.LookupStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.584 s -- in edu.illinois.library.cantaloupe.source.LookupStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.305 s -- in edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.820 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.FilesystemCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.02 s -- in edu.illinois.library.cantaloupe.cache.FilesystemCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 121.9 s -- in edu.illinois.library.cantaloupe.source.S3SourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.ConfigurationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.StatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.802 s -- in edu.illinois.library.cantaloupe.http.StatusTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 2.502 s -- in edu.illinois.library.cantaloupe.http.ClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.StatusResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.342 s -- in edu.illinois.library.cantaloupe.resource.api.ConfigurationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.DelegateOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.150 s -- in edu.illinois.library.cantaloupe.resource.api.StatusResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.676 s -- in edu.illinois.library.cantaloupe.operation.overlay.DelegateOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.ImageInfoUtilTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.DeletingFileVisitorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.814 s -- in edu.illinois.library.cantaloupe.resource.iiif.ImageInfoUtilTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.797 s -- in edu.illinois.library.cantaloupe.util.DeletingFileVisitorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.FormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.015 s -- in edu.illinois.library.cantaloupe.image.FormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.834 s -- in edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.589 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.PermissiveAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.182 s -- in edu.illinois.library.cantaloupe.auth.PermissiveAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000KakaduImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.175 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.803 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg2000.JPEG2000KakaduImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.EncodeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.IncompatibleSourceExceptionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.818 s -- in edu.illinois.library.cantaloupe.processor.IncompatibleSourceExceptionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.454 s -- in edu.illinois.library.cantaloupe.operation.EncodeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.iptc.ReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.739 s -- in edu.illinois.library.cantaloupe.image.iptc.ReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.iptc.ReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.DeletingFileVisitorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.788 s -- in edu.illinois.library.cantaloupe.image.iptc.ReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.811 s -- in edu.illinois.library.cantaloupe.util.DeletingFileVisitorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.FormatRegistryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.930 s -- in edu.illinois.library.cantaloupe.image.FormatRegistryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.795 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.ConfigurationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ProcessorConnectorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.775 s -- in edu.illinois.library.cantaloupe.config.ConfigurationFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.RotateTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.957 s -- in edu.illinois.library.cantaloupe.processor.ProcessorConnectorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.977 s -- in edu.illinois.library.cantaloupe.operation.RotateTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.StandaloneEntryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ErrorResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | DejaVu Sans
+[CI/build-4                               ]   | cantaloupe-1  | DejaVu Sans Mono
+[CI/build-4                               ]   | cantaloupe-1  | DejaVu Serif
+[CI/build-4                               ]   | cantaloupe-1  | Dialog
+[CI/build-4                               ]   | cantaloupe-1  | DialogInput
+[CI/build-4                               ]   | cantaloupe-1  | Monospaced
+[CI/build-4                               ]   | cantaloupe-1  | SansSerif
+[CI/build-4                               ]   | cantaloupe-1  | Serif
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Not a file: /home/cantaloupe/src/test/resources
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | VM arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Command arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Does not exist: /bla/bla/bla
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | VM arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Command arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Not a file: /home/cantaloupe
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | VM arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Command arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | VM arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Command arguments:
+[CI/build-4                               ]   | cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-4                               ]   | cantaloupe-1  | 
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.882 s -- in edu.illinois.library.cantaloupe.StandaloneEntryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.OkHttpHTTPImageInputStreamClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.063 s -- in edu.illinois.library.cantaloupe.resource.ErrorResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.118 s -- in edu.illinois.library.cantaloupe.source.OkHttpHTTPImageInputStreamClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.269 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ReductionFactorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.793 s -- in edu.illinois.library.cantaloupe.operation.ReductionFactorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.ImageReaderFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.469 s -- in edu.illinois.library.cantaloupe.processor.codec.ImageReaderFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.609 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.BasicImageOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.OverlayFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.784 s -- in edu.illinois.library.cantaloupe.operation.overlay.BasicImageOverlayServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.935 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.DataTypeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.094 s -- in edu.illinois.library.cantaloupe.image.exif.DataTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.133 s -- in edu.illinois.library.cantaloupe.operation.overlay.OverlayFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.KeyValuePairTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.SourceUsageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.783 s -- in edu.illinois.library.cantaloupe.http.KeyValuePairTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.823 s -- in edu.illinois.library.cantaloupe.status.SourceUsageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.ApplicationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.753 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.786 s -- in edu.illinois.library.cantaloupe.ApplicationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.FeatureTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 66, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.947 s -- in edu.illinois.library.cantaloupe.operation.ScaleByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.839 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.FeatureTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.HealthTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.847 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.840 s -- in edu.illinois.library.cantaloupe.status.HealthTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.bmp.BMPImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.742 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.195 s -- in edu.illinois.library.cantaloupe.processor.codec.bmp.BMPImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.374 s -- in edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.211 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SourceFormatExceptionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.979 s -- in edu.illinois.library.cantaloupe.processor.SourceFormatExceptionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 30, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.579 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.InfoServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.287 s -- in edu.illinois.library.cantaloupe.resource.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.TimeUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.273 s -- in edu.illinois.library.cantaloupe.cache.InfoServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.755 s -- in edu.illinois.library.cantaloupe.util.TimeUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TasksResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.095 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.823 s -- in edu.illinois.library.cantaloupe.resource.InformationRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_1ConformanceTest
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:49:27.022 * 100 changes in 300 seconds. Saving...
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:49:27.022 * Background saving started by pid 31
+[CI/build-1                               ]   | redis-1                                | 31:C 31 Dec 2025 07:49:27.031 * DB saved on disk
+[CI/build-1                               ]   | redis-1                                | 31:C 31 Dec 2025 07:49:27.032 * Fork CoW for RDB: current 0 MB, peak 0 MB, average 0 MB
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:49:27.124 * Background saving terminated with success
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.292 s -- in edu.illinois.library.cantaloupe.resource.api.TasksResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.CookieTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.062 s -- in edu.illinois.library.cantaloupe.http.CookieTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.StandaloneEntryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | DejaVu Sans
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | DejaVu Sans Mono
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | DejaVu Serif
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Dialog
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | DialogInput
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Monospaced
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | SansSerif
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Serif
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Not a file: /home/cantaloupe/src/test/resources
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | VM arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Command arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Does not exist: /bla/bla/bla
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | VM arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Command arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Not a file: /home/cantaloupe
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | VM arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Command arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Usage: java <VM args> -jar classes <command args>
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | VM arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -Dcantaloupe.config=<path>       Configuration file (REQUIRED)
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Command arguments:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  |   -list-fonts                      List fonts
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/config.properties
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4.205 s -- in edu.illinois.library.cantaloupe.StandaloneEntryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MediaTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.55 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_1ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | detection failed: [format: webm] [file: webm]
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | detection failed:	format: webm	file: webm
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | detection failed:	format: webm	file: webm
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.171 s -- in edu.illinois.library.cantaloupe.image.MediaTypeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.RetrievalStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.756 s -- in edu.illinois.library.cantaloupe.processor.RetrievalStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.DimensionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.894 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.RegionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.940 s -- in edu.illinois.library.cantaloupe.image.DimensionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageWriterTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.898 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.OkHttpHTTPImageInputStreamClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 1.562 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.BasicImageOverlayServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.633 s -- in edu.illinois.library.cantaloupe.source.OkHttpHTTPImageInputStreamClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.InfoCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.808 s -- in edu.illinois.library.cantaloupe.operation.overlay.BasicImageOverlayServiceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.786 s -- in edu.illinois.library.cantaloupe.cache.InfoCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.DelegateMetaIdentifierTransformerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.324 s -- in edu.illinois.library.cantaloupe.image.DelegateMetaIdentifierTransformerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.744 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.669 s -- in edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.979 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ComplianceLevelTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.856 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.682 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 s -- in edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 61, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.239 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.StatusResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ManualSelectionStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.106 s -- in edu.illinois.library.cantaloupe.processor.ManualSelectionStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.226 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.406 s -- in edu.illinois.library.cantaloupe.resource.RequestContextTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.653 s -- in edu.illinois.library.cantaloupe.resource.admin.StatusResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 41, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.842 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.SizeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ColorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.918 s -- in edu.illinois.library.cantaloupe.operation.ColorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.stream.ClosingMemoryCacheImageInputStreamTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.781 s -- in edu.illinois.library.cantaloupe.source.stream.ClosingMemoryCacheImageInputStreamTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.FilesystemSourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.833 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ServiceFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.195 s -- in edu.illinois.library.cantaloupe.source.FilesystemSourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.791 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ServiceFeatureTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.NameFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.926 s -- in edu.illinois.library.cantaloupe.source.NameFormatCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.901 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.FieldTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.ConfigurationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.748 s -- in edu.illinois.library.cantaloupe.image.exif.FieldTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.PdfBoxProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 41, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.747 s -- in edu.illinois.library.cantaloupe.processor.PdfBoxProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.ReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.797 s -- in edu.illinois.library.cantaloupe.resource.admin.ConfigurationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.118 s -- in edu.illinois.library.cantaloupe.image.exif.ReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ErrorResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.StatusTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.919 s -- in edu.illinois.library.cantaloupe.http.StatusTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.650 s -- in edu.illinois.library.cantaloupe.resource.ErrorResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.352 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.201 s -- in edu.illinois.library.cantaloupe.image.InfoTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.913 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthInfoRestrictiveBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.QualityTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.793 s -- in edu.illinois.library.cantaloupe.auth.AuthInfoRestrictiveBuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.811 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.QualityTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_0ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.Java2DUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 58, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.665 s -- in edu.illinois.library.cantaloupe.processor.Java2DUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.Version3_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 12.39 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.QualityTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.098 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.QualityTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.ObjectCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.81 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.Version3_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.936 s -- in edu.illinois.library.cantaloupe.util.ObjectCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.PositionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.OutputFormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.736 s -- in edu.illinois.library.cantaloupe.operation.overlay.PositionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.iptc.DataSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.924 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.OutputFormatTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.881 s -- in edu.illinois.library.cantaloupe.image.iptc.DataSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.770 s -- in edu.illinois.library.cantaloupe.processor.SelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.Version1_1ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.JaiProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 40, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 6.493 s -- in edu.illinois.library.cantaloupe.processor.JaiProcessorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.ParametersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 35, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.76 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.Version1_1ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.933 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.ParametersTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.955 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3HTTPImageInputStreamClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.416 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.InfoServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.866 s -- in edu.illinois.library.cantaloupe.cache.InfoServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.709 s -- in edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.delegate.DelegateProxyServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.317 s -- in edu.illinois.library.cantaloupe.delegate.DelegateProxyServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.HealthCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.606 s -- in edu.illinois.library.cantaloupe.status.HealthCheckerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheWorkerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.534 s -- in edu.illinois.library.cantaloupe.cache.CacheWorkerTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.620 s -- in edu.illinois.library.cantaloupe.cache.CacheFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.SourceFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.955 s -- in edu.illinois.library.cantaloupe.source.SourceFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.715 s -- in edu.illinois.library.cantaloupe.resource.RequestContextTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.737 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.546 s -- in edu.illinois.library.cantaloupe.image.exif.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.MapConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 99, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.467 s -- in edu.illinois.library.cantaloupe.config.MapConfigurationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.RegionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.611 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.RegionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.StatusResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.746 s -- in edu.illinois.library.cantaloupe.resource.api.StatusResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.830 s -- in edu.illinois.library.cantaloupe.processor.codec.gif.GIFImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.StringOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.603 s -- in edu.illinois.library.cantaloupe.operation.overlay.StringOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.646 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.SizeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.ReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.551 s -- in edu.illinois.library.cantaloupe.image.exif.ReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.ScaleConstraintTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.552 s -- in edu.illinois.library.cantaloupe.image.ScaleConstraintTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.ApplicationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.595 s -- in edu.illinois.library.cantaloupe.ApplicationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.QueryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.571 s -- in edu.illinois.library.cantaloupe.http.QueryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.952 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.StopwatchTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.531 s -- in edu.illinois.library.cantaloupe.util.StopwatchTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.redaction.RedactionServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.930 s -- in edu.illinois.library.cantaloupe.operation.redaction.RedactionServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.BufferedImageSequenceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.526 s -- in edu.illinois.library.cantaloupe.processor.codec.BufferedImageSequenceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.561 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.OrientationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.569 s -- in edu.illinois.library.cantaloupe.image.OrientationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HTTPStreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 1.078 s -- in edu.illinois.library.cantaloupe.source.HTTPStreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.FileServletTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.593 s -- in edu.illinois.library.cantaloupe.resource.FileServletTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.AuthorizerFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.923 s -- in edu.illinois.library.cantaloupe.auth.AuthorizerFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3SourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 56.40 s -- in edu.illinois.library.cantaloupe.source.S3HTTPImageInputStreamClientTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.CommandLocatorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s -- in edu.illinois.library.cantaloupe.util.CommandLocatorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 46, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.606 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.RegionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.FormatRegistryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.732 s -- in edu.illinois.library.cantaloupe.image.FormatRegistryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.RotateTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.618 s -- in edu.illinois.library.cantaloupe.operation.RotateTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.HeritablePropertiesConfigurationTest
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level3.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level2.properties
+[CI/build-4                               ]   | cantaloupe-1  | Loading config file: /home/cantaloupe/src/test/resources/heritable_level1.properties
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 114, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.045 s -- in edu.illinois.library.cantaloupe.config.HeritablePropertiesConfigurationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.091 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.StatusResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.120 s -- in edu.illinois.library.cantaloupe.resource.admin.StatusResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.SystemUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.556 s -- in edu.illinois.library.cantaloupe.util.SystemUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestContextMapTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.695 s -- in edu.illinois.library.cantaloupe.resource.RequestContextMapTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.24 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.TrailingSlashRemovingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.902 s -- in edu.illinois.library.cantaloupe.resource.TrailingSlashRemovingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SourceCacheDownloadTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.576 s -- in edu.illinois.library.cantaloupe.processor.SourceCacheDownloadTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.079 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.553 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 0.624 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageReaderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.532 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.QualityTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.343 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.806 s -- in edu.illinois.library.cantaloupe.resource.ImageRequestHandlerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.162 s -- in edu.illinois.library.cantaloupe.image.MetadataTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.RedisCacheTest
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:53:03.815 * 100 changes in 300 seconds. Saving...
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:53:03.817 * Background saving started by pid 29
+[CI/build-4                               ]   | redis-1       | 29:C 31 Dec 2025 07:53:03.838 * DB saved on disk
+[CI/build-4                               ]   | redis-1       | 29:C 31 Dec 2025 07:53:03.839 * Fork CoW for RDB: current 0 MB, peak 0 MB, average 0 MB
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:53:03.919 * Background saving terminated with success
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 23, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 26.92 s -- in edu.illinois.library.cantaloupe.cache.RedisCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleByPercentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.595 s -- in edu.illinois.library.cantaloupe.operation.ScaleByPercentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.JdbcSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.244 s -- in edu.illinois.library.cantaloupe.source.JdbcSourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.iptc.DataSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.825 s -- in edu.illinois.library.cantaloupe.image.iptc.DataSetTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ContentTypeNegotiatorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.532 s -- in edu.illinois.library.cantaloupe.http.ContentTypeNegotiatorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.StringUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.683 s -- in edu.illinois.library.cantaloupe.util.StringUtilsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.159 s -- in edu.illinois.library.cantaloupe.http.ServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.DelegateAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.026 s -- in edu.illinois.library.cantaloupe.auth.DelegateAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.ImageReaderFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.729 s -- in edu.illinois.library.cantaloupe.processor.codec.ImageReaderFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.EnvironmentConfigurationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.537 s -- in edu.illinois.library.cantaloupe.config.EnvironmentConfigurationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.FilesystemCacheTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 121.7 s -- in edu.illinois.library.cantaloupe.source.S3SourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ProcessorConnectorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.410 s -- in edu.illinois.library.cantaloupe.processor.ProcessorConnectorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.527 s -- in edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.xmp.MapReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | ------ ELEMENTS -------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiAdrCity
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Urbana
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiAdrCtry
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | United States
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiAdrExtadr
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 1408 W. Gregory Drive
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiAdrPcode
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 61801
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiAdrRegion
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Illinois
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiEmailWork
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | dcc@library.illinois.edu
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiTelWork
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | +1+1(217)2442062
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:CiUrlWork
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | http://www.library.illinois.edu/dcc/
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Iptc4xmpCore:SubjectCode
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [new subject code, Preservation Master creation]
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | dc:creator
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | University of Illinois Library
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | dc:title
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Illini Union Photographs Record Series 3707005
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | exif:ExifVersion
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 0221
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | exif:Firmware
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | P40+-M, Firmware: Main=5.1.8, Boot=2.3, FPGA=1.2.4, CPLD=5.0.1, PAVR=1.0.3, UIFC=1.0.1, TGEN=1.0
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | exif:SerialNumber
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | EG031306
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | photoshop:Credit
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | JP Goguen
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | photoshop:DateCreated
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | 2012-10-03T14:25:41-05:00
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | photoshop:TransmissionReference
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | Access Jpeg
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | xmp:UsageTerms
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | No reproduction without prior permission
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | -------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.960 s -- in edu.illinois.library.cantaloupe.image.xmp.MapReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropByPixelsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 45, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.771 s -- in edu.illinois.library.cantaloupe.operation.CropByPixelsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HTTPRequestInfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.565 s -- in edu.illinois.library.cantaloupe.source.HTTPRequestInfoTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ResponseTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.027 s -- in edu.illinois.library.cantaloupe.http.ResponseTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.auth.PermissiveAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 40, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.27 s -- in edu.illinois.library.cantaloupe.cache.FilesystemCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.760 s -- in edu.illinois.library.cantaloupe.auth.PermissiveAuthorizerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.773 s -- in edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.RectangleTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.ConfigurationResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.896 s -- in edu.illinois.library.cantaloupe.image.RectangleTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.DimensionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.943 s -- in edu.illinois.library.cantaloupe.image.DimensionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.api.TaskResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.663 s -- in edu.illinois.library.cantaloupe.resource.api.ConfigurationResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.S3StreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.742 s -- in edu.illinois.library.cantaloupe.resource.api.TaskResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.TaskQueueTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.405 s -- in edu.illinois.library.cantaloupe.async.TaskQueueTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.ParametersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.960 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.ParametersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.InformationFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.025 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.InformationFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.bmp.BMPImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.774 s -- in edu.illinois.library.cantaloupe.processor.codec.bmp.BMPImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropByPercentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.616 s -- in edu.illinois.library.cantaloupe.operation.CropByPercentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.BasicStringOverlayServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.525 s -- in edu.illinois.library.cantaloupe.operation.overlay.BasicStringOverlayServiceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheFacadeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.876 s -- in edu.illinois.library.cantaloupe.cache.CacheFacadeTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.HeadersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.621 s -- in edu.illinois.library.cantaloupe.http.HeadersTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.075 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.563 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.GrokProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 38, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.053 s -- in edu.illinois.library.cantaloupe.processor.GrokProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 6, Time elapsed: 0.638 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.TurboJPEGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest$BuilderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 82, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.207 s -- in edu.illinois.library.cantaloupe.operation.OperationListTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.008 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.StringUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.681 s -- in edu.illinois.library.cantaloupe.util.StringUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.254 s -- in edu.illinois.library.cantaloupe.http.ClientTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.Version3_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 53, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.382 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.Version3_0ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.856 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.136 s -- in edu.illinois.library.cantaloupe.processor.codec.jpeg.JPEGMetadataTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 76.29 s -- in edu.illinois.library.cantaloupe.source.S3StreamFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ReductionFactorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.560 s -- in edu.illinois.library.cantaloupe.operation.ReductionFactorTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.LookupStrategyTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.566 s -- in edu.illinois.library.cantaloupe.source.LookupStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.81 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.StringOverlayTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.668 s -- in edu.illinois.library.cantaloupe.operation.overlay.StringOverlayTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.PositionTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.902 s -- in edu.illinois.library.cantaloupe.operation.overlay.PositionTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 9, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.674 s -- in edu.illinois.library.cantaloupe.http.ServerTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.S3MultipartAsyncOutputStreamTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.PathStreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.544 s -- in edu.illinois.library.cantaloupe.source.PathStreamFactoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.SourceCacheDownloadTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.576 s -- in edu.illinois.library.cantaloupe.processor.SourceCacheDownloadTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.577 s -- in edu.illinois.library.cantaloupe.util.RationalTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v3.RotationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.599 s -- in edu.illinois.library.cantaloupe.resource.iiif.v3.RotationTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.AdminResourceUITest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.22 s -- in edu.illinois.library.cantaloupe.cache.S3MultipartAsyncOutputStreamTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.TaskQueueTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.938 s -- in edu.illinois.library.cantaloupe.async.TaskQueueTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.async.ThreadPoolTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.754 s -- in edu.illinois.library.cantaloupe.async.ThreadPoolTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in edu.illinois.library.cantaloupe.operation.ScaleTest$FilterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 66, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.058 s -- in edu.illinois.library.cantaloupe.operation.ScaleByPixelsTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.RequestTest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.760 s -- in edu.illinois.library.cantaloupe.resource.RequestTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.AbstractResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.725 s -- in edu.illinois.library.cantaloupe.resource.AbstractResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.cache.CacheFacadeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.227 s -- in edu.illinois.library.cantaloupe.cache.CacheFacadeTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.JAIUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.098 s -- in edu.illinois.library.cantaloupe.processor.JAIUtilTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.source.HttpSourceHTTPS1Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.43 s -- in edu.illinois.library.cantaloupe.resource.admin.AdminResourceUITest
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 5.652 s -- in edu.illinois.library.cantaloupe.source.HttpSourceHTTPS1Test
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v1.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.exif.DirectoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.803 s -- in edu.illinois.library.cantaloupe.resource.iiif.v1.RotationTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.153 s -- in edu.illinois.library.cantaloupe.image.exif.DirectoryTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_1ConformanceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.162 s -- in edu.illinois.library.cantaloupe.operation.overlay.ImageOverlayCacheTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropByPercentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.276 s -- in edu.illinois.library.cantaloupe.operation.CropByPercentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.QueryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.077 s -- in edu.illinois.library.cantaloupe.http.QueryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.687 s -- in edu.illinois.library.cantaloupe.processor.codec.tiff.TIFFImageWriterTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.LandingResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 11.74 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.Version2_1ConformanceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.478 s -- in edu.illinois.library.cantaloupe.resource.LandingResourceTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 31, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.805 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.InformationFactoryTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.125 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest$BuilderTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.980 s -- in edu.illinois.library.cantaloupe.image.MetaIdentifierTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.CropToSquareTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.AutomaticSelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.798 s -- in edu.illinois.library.cantaloupe.operation.CropToSquareTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.944 s -- in edu.illinois.library.cantaloupe.processor.AutomaticSelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.status.SourceUsageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.util.TimeUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.807 s -- in edu.illinois.library.cantaloupe.status.SourceUsageTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.817 s -- in edu.illinois.library.cantaloupe.util.TimeUtilsTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.config.PropertiesDocumentTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.252 s -- in edu.illinois.library.cantaloupe.image.InfoTest$InfoImageTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.937 s -- in edu.illinois.library.cantaloupe.image.InfoTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.902 s -- in edu.illinois.library.cantaloupe.config.PropertiesDocumentTest
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Results:
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [WARNING] Tests run: 4016, Failures: 0, Errors: 0, Skipped: 35
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] 
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] BUILD SUCCESS
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Total time:  21:39 min
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] Finished at: 2025-12-31T07:56:57Z
+[CI/build-4                               ]   | cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.iiif.v2.OutputFormatTest
+[CI/build-4                               ]   | [Kcantaloupe-1 exited with code 0
+[CI/build-4                               ]   | [31m[1mAborting on container exit...[0m
+[CI/build-4                               ]   |  Container linux-jdk21-cantaloupe-1  Stopping
+[CI/build-4                               ]   |  Container linux-jdk21-minio-1  Stopping
+[CI/build-4                               ]   |  Container linux-jdk21-redis-1  Stopping
+[CI/build-4                               ]   |  Container linux-jdk21-cantaloupe-1  Stopped
+[CI/build-4                               ]   | redis-1       | 1:signal-handler (1767167818) Received SIGTERM scheduling shutdown...
+[CI/build-4                               ]   | minio-1       | INFO: Exiting on signal: TERMINATED
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:56:58.037 * User requested shutdown...
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:56:58.038 * Saving the final RDB snapshot before exiting.
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:56:58.050 * DB saved on disk
+[CI/build-4                               ]   | redis-1       | 1:M 31 Dec 2025 07:56:58.050 # Redis is now ready to exit, bye bye...
+[CI/build-4                               ]   |  Container linux-jdk21-redis-1  Stopped
+[CI/build-4                               ]   | [Kredis-1 exited with code 0
+[CI/build-4                               ]   |  Container linux-jdk21-minio-1  Stopped
+[CI/build-4                               ]   | [Kminio-1 exited with code 0
+[CI/build-4                               ]   ✅  Success - Main Test in Linux JDK 21 (LTS) [21m43.343031037s]
+[CI/build-4                               ] ⭐ Run Complete job
+[CI/build-4                               ] Cleaning up container for job build
+[CI/build-4                               ]   ✅  Success - Complete job
+[CI/build-4                               ] 🏁  Job succeeded
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.871 s -- in edu.illinois.library.cantaloupe.resource.iiif.v2.OutputFormatTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.ManualSelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.674 s -- in edu.illinois.library.cantaloupe.processor.ManualSelectionStrategyTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.http.ContentTypeNegotiatorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.609 s -- in edu.illinois.library.cantaloupe.http.ContentTypeNegotiatorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.resource.admin.AdminResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.784 s -- in edu.illinois.library.cantaloupe.resource.admin.AdminResourceTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.codec.png.PNGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.806 s -- in edu.illinois.library.cantaloupe.processor.codec.png.PNGImageReaderTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.processor.TurboJpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 38, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 1.349 s -- in edu.illinois.library.cantaloupe.processor.TurboJpegProcessorTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Running edu.illinois.library.cantaloupe.operation.SharpenTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.571 s -- in edu.illinois.library.cantaloupe.operation.SharpenTest
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Results:
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [WARNING] Tests run: 4016, Failures: 0, Errors: 0, Skipped: 35
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] 
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] BUILD SUCCESS
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Total time:  21:50 min
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] Finished at: 2025-12-31T07:57:11Z
+[CI/build-1                               ]   | 00f9504640d2_linux-jdk17-cantaloupe-1  | [INFO] ------------------------------------------------------------------------
+[CI/build-1                               ]   | [31m[1mAborting on container exit...[0m
+[CI/build-1                               ]   | [K00f9504640d2_linux-jdk17-cantaloupe-1 exited with code 0
+[CI/build-1                               ]   |  Container linux-jdk17-minio-1  Stopping
+[CI/build-1                               ]   |  Container 00f9504640d2_linux-jdk17-cantaloupe-1  Stopping
+[CI/build-1                               ]   |  Container linux-jdk17-redis-1  Stopping
+[CI/build-1                               ]   |  Container 00f9504640d2_linux-jdk17-cantaloupe-1  Stopped
+[CI/build-1                               ]   | minio-1                                | INFO: Exiting on signal: TERMINATED
+[CI/build-1                               ]   | redis-1                                | 1:signal-handler (1767167831) Received SIGTERM scheduling shutdown...
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:57:11.464 * User requested shutdown...
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:57:11.464 * Saving the final RDB snapshot before exiting.
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:57:11.473 * DB saved on disk
+[CI/build-1                               ]   | redis-1                                | 1:M 31 Dec 2025 07:57:11.473 # Redis is now ready to exit, bye bye...
+[CI/build-1                               ]   |  Container linux-jdk17-redis-1  Stopped
+[CI/build-1                               ]   | [Kredis-1 exited with code 0
+[CI/build-1                               ]   |  Container linux-jdk17-minio-1  Stopped
+[CI/build-1                               ]   | [Kminio-1 exited with code 0
+[CI/build-1                               ]   ✅  Success - Main Test in Linux JDK 17 (LTS) [21m56.768409689s]
+[CI/build-1                               ] ⭐ Run Complete job
+[CI/build-1                               ] Cleaning up container for job build
+[CI/build-1                               ]   ✅  Success - Complete job
+[CI/build-1                               ] 🏁  Job succeeded

--- a/pom.xml
+++ b/pom.xml
@@ -186,8 +186,22 @@
         <!-- JUnit for unit tests. -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version> 5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.13.4</version>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- JUnit Pioneer for extended test functionality -->
+        <!-- JUnit version down 5.13.4 to 5.11.4 -->
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Performance tests -->

--- a/src/test/java/edu/illinois/library/cantaloupe/async/AuditableFutureTaskTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/async/AuditableFutureTaskTest.java
@@ -3,6 +3,7 @@ package edu.illinois.library.cantaloupe.async;
 import edu.illinois.library.cantaloupe.test.BaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -83,7 +84,7 @@ public class AuditableFutureTaskTest extends BaseTest {
         assertTrue(delta < 10);
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testRunSetsStatusWhenStarted() throws Exception {
         AuditableFutureTask<?> task = new AuditableFutureTask<Void>(() -> {
             Thread.sleep(50);

--- a/src/test/java/edu/illinois/library/cantaloupe/async/TaskQueueTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/async/TaskQueueTest.java
@@ -4,6 +4,7 @@ import edu.illinois.library.cantaloupe.test.BaseTest;
 import org.apache.tika.utils.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.util.concurrent.FutureTask;
 
@@ -23,7 +24,7 @@ public class TaskQueueTest extends BaseTest {
 
     /* queuedTasks() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testQueuedTasks() throws Exception {
         for (int i = 0; i < 3; i++) {
             instance.submit(new FutureTask<>(new MockCallable<>()));
@@ -37,7 +38,7 @@ public class TaskQueueTest extends BaseTest {
 
     /* submit(Callable<?>) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitCallable() throws Exception {
         MockCallable<?> callable1 = new MockCallable<>();
         MockCallable<?> callable2 = new MockCallable<>();
@@ -60,7 +61,7 @@ public class TaskQueueTest extends BaseTest {
 
     /* submit(Runnable) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitRunnable() throws Exception {
         MockRunnable runnable1 = new MockRunnable();
         MockRunnable runnable2 = new MockRunnable();
@@ -83,7 +84,7 @@ public class TaskQueueTest extends BaseTest {
 
     /* submit(Runnable) with AuditableFutureTask */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsQueuedTaskStatus() throws Exception {
         AuditableFutureTask<?> future1 =
                 new AuditableFutureTask<>(new MockCallable<>());
@@ -101,7 +102,7 @@ public class TaskQueueTest extends BaseTest {
         assertEquals(TaskStatus.QUEUED, future2.getStatus());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsRunningTaskStatus() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO: why does this fail in Windows?
 
@@ -122,7 +123,7 @@ public class TaskQueueTest extends BaseTest {
         assertNotNull(future.getInstantQueued());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsInstantStarted() throws Exception {
         MockCallable<?> task = new MockCallable<>();
         AuditableFutureTask<?> future = new AuditableFutureTask<>(task);
@@ -131,7 +132,7 @@ public class TaskQueueTest extends BaseTest {
         assertNotNull(future.getInstantStarted());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsInstantStopped() throws Exception {
         MockCallable<?> task = new MockCallable<>();
         AuditableFutureTask<?> future = new AuditableFutureTask<>(task);
@@ -140,7 +141,7 @@ public class TaskQueueTest extends BaseTest {
         assertNotNull(future.getInstantStopped());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsSuccessfulTaskStatus()
             throws Exception {
         MockCallable<?> task = new MockCallable<>();
@@ -152,7 +153,7 @@ public class TaskQueueTest extends BaseTest {
         assertEquals(TaskStatus.SUCCEEDED, future.getStatus());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSubmitAuditableFutureTaskSetsFailedTaskStatus() throws Exception {
         MockFailingCallable<?> task = new MockFailingCallable<>();
         AuditableFutureTask<?> future = new AuditableFutureTask<>(task);

--- a/src/test/java/edu/illinois/library/cantaloupe/cache/AbstractCacheTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/AbstractCacheTest.java
@@ -12,6 +12,7 @@ import edu.illinois.library.cantaloupe.test.ConcurrentReaderWriter;
 import edu.illinois.library.cantaloupe.test.TestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -69,7 +70,7 @@ abstract class AbstractCacheTest extends BaseTest {
         assertEquals(actual.orElseThrow(), info);
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testGetInfoWithExistingInvalidImage() throws Exception {
         final DerivativeCache instance = newInstance();
         Configuration.getInstance().setProperty(Key.DERIVATIVE_CACHE_TTL, 1);
@@ -113,7 +114,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* newDerivativeImageInputStream(OperationList) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testNewDerivativeImageInputStreamWithZeroTTL() throws Exception {
         final DerivativeCache instance = newInstance();
         Configuration.getInstance().setProperty(Key.DERIVATIVE_CACHE_TTL, 0);
@@ -143,7 +144,7 @@ abstract class AbstractCacheTest extends BaseTest {
         }
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testNewDerivativeImageInputStreamWithNonzeroTTL() throws Exception {
         final DerivativeCache instance = newInstance();
         Configuration.getInstance().setProperty(Key.DERIVATIVE_CACHE_TTL, 3);
@@ -218,7 +219,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* newDerivativeImageOutputStream() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testNewDerivativeImageOutputStream() throws Exception {
         final DerivativeCache instance = newInstance();
         final OperationList ops = OperationList.builder()
@@ -287,7 +288,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* purge() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurge() throws Exception {
         DerivativeCache instance = newInstance();
         Identifier identifier = new Identifier(IMAGE);
@@ -337,7 +338,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* purge(Identifier) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeWithIdentifier() throws Exception {
         DerivativeCache instance = newInstance();
 
@@ -394,7 +395,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* purge(OperationList) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeWithOperationList() throws Exception {
         final DerivativeCache instance = newInstance();
 
@@ -434,7 +435,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* purgeInfos() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInfos() throws Exception {
         DerivativeCache instance = newInstance();
         Identifier identifier    = new Identifier(IMAGE);
@@ -481,7 +482,7 @@ abstract class AbstractCacheTest extends BaseTest {
 
     /* purgeInvalid() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInvalid() throws Exception {
         DerivativeCache instance = newInstance();
         Identifier id1           = new Identifier(IMAGE);

--- a/src/test/java/edu/illinois/library/cantaloupe/cache/CacheFacadeTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/CacheFacadeTest.java
@@ -13,6 +13,7 @@ import edu.illinois.library.cantaloupe.test.TestUtil;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -324,7 +325,7 @@ public class CacheFacadeTest extends BaseTest {
 
     /* purgeAsync(Identifier) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeAsyncWithIdentifier() throws Exception {
         enableDerivativeCache();
         SourceCache sourceCache    = CacheFactory.getSourceCache().get();
@@ -394,7 +395,7 @@ public class CacheFacadeTest extends BaseTest {
 
     /* purgeInfos() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInfos() throws Exception {
         final Configuration config = Configuration.getInstance();
         config.setProperty(Key.DERIVATIVE_CACHE_TTL, 1);
@@ -422,7 +423,7 @@ public class CacheFacadeTest extends BaseTest {
 
     /* purgeInvalid() */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInvalid() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO: this fails in Windows CI
 

--- a/src/test/java/edu/illinois/library/cantaloupe/cache/FilesystemCacheTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/FilesystemCacheTest.java
@@ -18,6 +18,7 @@ import edu.illinois.library.cantaloupe.util.DeletingFileVisitor;
 import edu.illinois.library.cantaloupe.util.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -266,7 +267,7 @@ public class FilesystemCacheTest extends AbstractCacheTest {
         assertRecursiveFileCount(fixturePath, 12);
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testCleanUpDeletesInvalidFiles() throws Exception {
         OperationList ops = new OperationList(new Identifier("cats"));
 
@@ -354,7 +355,7 @@ public class FilesystemCacheTest extends AbstractCacheTest {
         assertTrue(instance.getSourceImageFile(identifier).isPresent());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testGetSourceImageFileWithNonzeroTTL() throws Exception {
         Configuration.getInstance().setProperty(Key.SOURCE_CACHE_TTL, 1);
 
@@ -508,7 +509,7 @@ public class FilesystemCacheTest extends AbstractCacheTest {
      * Override that also tests the source cache.
      */
     @Override
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInvalid() throws Exception {
         final Configuration config = Configuration.getInstance();
         config.setProperty(Key.SOURCE_CACHE_TTL, 1);

--- a/src/test/java/edu/illinois/library/cantaloupe/cache/JdbcCacheTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/JdbcCacheTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -228,7 +229,7 @@ public class JdbcCacheTest extends AbstractCacheTest {
 
     /* getInfo(Identifier) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testGetImageInfoUpdatesLastAccessedTime() throws Exception {
         final Configuration config = Configuration.getInstance();
 
@@ -276,7 +277,7 @@ public class JdbcCacheTest extends AbstractCacheTest {
     @Test
     void testNewDerivativeImageInputStreamWithNonzeroTTL() {}
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testNewDerivativeImageInputStreamUpdatesLastAccessedTime()
             throws Exception {
         final Configuration config = Configuration.getInstance();
@@ -323,7 +324,7 @@ public class JdbcCacheTest extends AbstractCacheTest {
     void testNewDerivativeImageOutputStream() {}
 
     @Override
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurge() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO: why does this fail in Windows?
 
@@ -402,7 +403,7 @@ public class JdbcCacheTest extends AbstractCacheTest {
      * JDBC cache has more complex async operations that need more time in CI environments.
      */
     @Override
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInfos() throws Exception {
         Identifier identifier = new Identifier(IMAGE);
         OperationList opList = OperationList.builder()

--- a/src/test/java/edu/illinois/library/cantaloupe/cache/S3CacheTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/S3CacheTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -190,7 +191,7 @@ public class S3CacheTest extends AbstractCacheTest {
 
     /* getInfo(Identifier) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testGetInfoUpdatesLastModifiedTime() throws Exception {
         Configuration.getInstance().setProperty(Key.DERIVATIVE_CACHE_TTL, 1);
 
@@ -244,7 +245,7 @@ public class S3CacheTest extends AbstractCacheTest {
         assertEquals("cats/", instance.getObjectKeyPrefix());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     @Override
     void testNewDerivativeImageInputStreamWithNonzeroTTL() throws Exception {
         assumeFalse(Service.AWS.equals(getService()));  // TODO: this test fails in AWS
@@ -252,7 +253,7 @@ public class S3CacheTest extends AbstractCacheTest {
         super.testNewDerivativeImageInputStreamWithNonzeroTTL();
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testNewDerivativeImageInputStreamUpdatesLastModifiedTime()
             throws Exception {
         assumeFalse(Service.MINIO.equals(getService())); // this test fails in minio
@@ -291,8 +292,8 @@ public class S3CacheTest extends AbstractCacheTest {
     }
 
     /* purge() */
-    @Test
     @Override
+    @RetryingTest(maxAttempts = 5)
     void testPurge() throws Exception {
         DerivativeCache instance = newInstance();
         Identifier identifier = new Identifier(IMAGE);
@@ -341,7 +342,7 @@ public class S3CacheTest extends AbstractCacheTest {
         assertNotExists(instance, opList);
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeWithKeyPrefix() throws Exception {
         final String prefix = "prefix/";
         final Configuration config = Configuration.getInstance();
@@ -405,8 +406,8 @@ public class S3CacheTest extends AbstractCacheTest {
 
     /* purgeInvalid() */
 
-    @Test
     @Override
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInvalid() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO: this fails in Windows sometimes
 
@@ -461,7 +462,7 @@ public class S3CacheTest extends AbstractCacheTest {
 
 
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testPurgeInvalidWithKeyPrefix() throws Exception {
         final String prefix        = "prefix/";
         final Configuration config = Configuration.getInstance();
@@ -523,7 +524,7 @@ public class S3CacheTest extends AbstractCacheTest {
 
     /* purge(Identifier) */
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     @Override
     void testPurgeWithIdentifier() throws Exception {
         assumeFalse(SystemUtils.IS_OS_WINDOWS); // TODO: this fails in Windows sometimes

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/ImageRequestHandlerTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/ImageRequestHandlerTest.java
@@ -19,6 +19,7 @@ import edu.illinois.library.cantaloupe.test.TestUtil;
 import edu.illinois.library.cantaloupe.test.WebServer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -542,7 +543,7 @@ class ImageRequestHandlerTest extends BaseTest {
         }
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void handleDeletesIncompatibleSourceCachedImageWhenSoConfigured()
             throws Exception {
         final WebServer server = new WebServer();
@@ -604,7 +605,7 @@ class ImageRequestHandlerTest extends BaseTest {
         }
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void handleDoesNotDeleteIncompatibleSourceCachedImageWhenNotConfiguredTo()
             throws Exception {
         final WebServer server = new WebServer();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AdminResourceUITest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AdminResourceUITest.java
@@ -6,6 +6,7 @@ import edu.illinois.library.cantaloupe.resource.Route;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -92,7 +93,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
         return new Select(inputNamed(key));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testApplicationSection() throws Exception {
         css("#cl-application-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -226,7 +227,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
                 config.getString(Key.ACCESS_LOG_SYSLOGAPPENDER_FACILITY));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testServerSection() throws Exception {
         css("#cl-http-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -274,7 +275,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
         assertTrue(config.getBoolean(Key.PRINT_STACK_TRACE_ON_ERROR_PAGES));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testEndpointsSection() throws Exception {
         css("#cl-endpoints-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -323,7 +324,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
                 config.getString(Key.STANDARD_META_IDENTIFIER_TRANSFORMER_DELIMITER));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testSourceSection() throws Exception {
         css("#cl-source-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -487,7 +488,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
                 config.getString(Key.JDBCSOURCE_CONNECTION_TIMEOUT));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testProcessorsSection() throws Exception {
         css("#cl-processors-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -577,7 +578,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
                 config.getLongBytes(Key.PROCESSOR_PDF_MAX_MEMORY_BYTES));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testCachesSection() throws Exception {
         css("#cl-caches-button > a").click();
         Thread.sleep(100); // give the tab time to render
@@ -705,7 +706,7 @@ public class AdminResourceUITest extends AbstractAdminResourceTest {
         assertEquals("5", config.getString(Key.REDISCACHE_DATABASE));
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 5)
     void testOverlaysSection() throws Exception {
         css("#cl-overlays-button > a").click();
         Thread.sleep(100); // give the tab time to render


### PR DESCRIPTION
**Critical JUnit Downgrade:**
- Downgrade JUnit Jupiter for compatibility with JUnit Pioneer 2.3.0
- This version compatibility issue was causing CI test failures across all JDK versions

**Problem Identified:**
CI failed with 'OutputDirectoryProvider not available' and timing-dependent test failures. Tests using Thread.sleep() exhibited race conditions due to timing differences in newer JVM versions.

**Solution:**
- Add JUnit Pioneer 2.3.0 dependency for @RetryingTest annotation
- Apply @RetryingTest(maxAttempts = 5) to 47 test methods containing Thread.sleep()
- This allows automatic retry of flaky timing-dependent tests up to 5 times

**Files Modified:**
- pom.xml: Version downgrade and dependency addition
- AbstractCacheTest.java: 10 methods with @RetryingTest
- S3CacheTest.java: 8 methods with @RetryingTest
- JdbcCacheTest.java: 4 methods with @RetryingTest
- TaskQueueTest.java: 9 methods with @RetryingTest
- CacheFacadeTest.java: 3 methods with @RetryingTest
- FilesystemCacheTest.java: 3 methods with @RetryingTest
- AuditableFutureTaskTest.java: 1 method with @RetryingTest
- AdminResourceUITest.java: 7 methods with @RetryingTest
- ImageRequestHandlerTest.java: 2 methods with @RetryingTest

**Related:**
See PR #886 for additional context on JDK compatibility improvements