### PR TITLE
Upgrade to jetty 12.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <maven.compile.target>17</maven.compile.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>12.1.2</jetty.version>
+        <jetty.version>12.1.3</jetty.version>
         <aws-sdk.version>2.21.4</aws-sdk.version>
         <jackson.version>2.15.2</jackson.version>
         <jruby.version>10.0.3.0</jruby.version>


### PR DESCRIPTION
See https://github.com/jetty/jetty.project/releases/tag/jetty-12.1.3

This is the last version of jetty 12 that we can upgrade to without upgrading slf4j. See #902 