### PR TITLE
Fix potential deadlock in GrokProcessor #912

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/GrokProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/GrokProcessor.java
@@ -497,6 +497,11 @@ class GrokProcessor  extends AbstractProcessor implements FileProcessor {
                         EnumSet.of(ReaderHint.ALREADY_CROPPED);
 
                 BufferedImage image = reader.read(0);
+
+                // Drain any remaining bytes (e.g. ICC profiles) from the stdout pipe.
+                // If we don't, the OS pipe buffer may fill up and hang grk_decompress
+                processInputStream.transferTo(OutputStream.nullOutputStream());
+
                 image = Java2DPostProcessor.postProcess(
                         image, hints, opList, info, reductionFactor);
 


### PR DESCRIPTION
Fix for https://github.com/cantaloupe-project/cantaloupe/issues/912

# Explanation by AI:

Based on the thread dump, source code, and symptoms you provided, you've run into a classic **Java Process pipe deadlock**. 

Here is exactly what is happening and how to fix it.

### The Root Cause

1. **The Architecture**: In Unix, `GrokProcessor` tells `grk_decompress` to output the converted `.bmp` file to a symlink pointing to `/dev/stdout`. Java captures this via `process.getInputStream()`.
2. **The Read**: Java uses `BMPImageReader` to read the image. `BMPImageReader` is efficient—it reads the BMP header, figures out the dimensions, reads the exact bytes for the pixel array, and **stops reading immediately**.
3. **The Leftover Data**: Newer versions of Grok (`grokj2k`) often extract the ICC color profile or other metadata from the JP2 and embed it at the *end* of the resulting BMP file.
4. **The Deadlock**: When `BMPImageReader` stops reading, any trailing metadata (like the ICC profile) remains unread in the OS pipe buffer (which is typically 64KB on Linux). If this trailing data is larger than 64KB, the pipe fills up. `grk_decompress` gets blocked on a `write()` system call and cannot exit.
5. **The Hang**: 
    - Java successfully processes the parsed image and flushes it to the client (which is why you receive all the image bytes).
    - Java then reaches line 507: `final int code = process.waitFor();`
    - Because `grk_decompress` is blocked trying to write the rest of the metadata to a full pipe, it never exits. `waitFor()` blocks forever.
    - Since the handler method never returns, the Jetty server never sends the HTTP EOF chunk, and your client hangs indefinitely.

This explains why it works manually (writing to disk doesn't block like a pipe), why it works for most images (those images either lack an ICC profile or it's small enough to fit in the 64KB pipe buffer), and why `OpenJpegProcessor` works (it likely doesn't append the ICC profile to the BMP).

### The Fix

To solve this, we must ensure that Java drains the remainder of the process's standard output before calling `process.waitFor()`. This will unblock `grk_decompress` so it can exit cleanly.

You will need to patch the `GrokProcessor.java` file. Locate the `processInUnix` method and add the stream drain command right after `reader.read(0)`:

```java
// Around line 497 in GrokProcessor.java

BufferedImage image = reader.read(0);

// --- ADD THESE LINES TO FIX THE DEADLOCK ---
// Drain any remaining bytes (e.g. ICC profiles) from the stdout pipe.
// If we don't, the OS pipe buffer fills up, grk_decompress hangs,
// and process.waitFor() blocks indefinitely.
processInputStream.transferTo(OutputStream.nullOutputStream());
// -------------------------------------------

image = Java2DPostProcessor.postProcess(
        image, hints, opList, info, reductionFactor);

ImageWriterFacade.write(image,
        (Encode) opList.getFirst(Encode.class),
        outputStream);

final int code = process.waitFor();
```

*(Note: `transferTo(OutputStream.nullOutputStream())` is available because Cantaloupe 5.x requires Java 11+).*

By silently consuming and discarding the remaining bytes in the pipe, `grk_decompress` is allowed to finish its write operation, exit with code 0, and allow `process.waitFor()` to continue smoothly.