### PR TITLE
Move the identifier methods into the Request object

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/image/Identifier.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/Identifier.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  *
  * <p>The input steps must be reversed for output. Note that requests can
  * supply a {@link
- * edu.illinois.library.cantaloupe.resource.AbstractResource#PUBLIC_IDENTIFIER_HEADER}
+ * edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER}
  * to suggest that the identifier supplied in a URI is different from the one
  * the user agent is seeing and supplying to a reverse proxy.</p>
  *
@@ -48,7 +48,7 @@ import java.io.IOException;
  *
  * <ol>
  *     <li>Replace the URI identifier with the one from {@link
- *     edu.illinois.library.cantaloupe.resource.AbstractResource#PUBLIC_IDENTIFIER_HEADER},
+ *     edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER},
  *     if present</li>
  *     <li>Encode slashes</li>
  *     <li>URI encoding</li>

--- a/src/main/java/edu/illinois/library/cantaloupe/image/MetaIdentifier.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/MetaIdentifier.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  *
  * <p>The input steps must be reversed for output. Note that requests can
  * supply a {@link
- * edu.illinois.library.cantaloupe.resource.AbstractResource#PUBLIC_IDENTIFIER_HEADER}
+ * edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER}
  * to suggest that the meta-identifier supplied in a URI is different from the
  * one the user agent is seeing and supplying to a reverse proxy.</p>
  *
@@ -48,7 +48,7 @@ import java.util.Objects;
  *
  * <ol>
  *     <li>Replace the URI meta-identifier with the one from {@link
- *     edu.illinois.library.cantaloupe.resource.AbstractResource#PUBLIC_IDENTIFIER_HEADER},
+ *     edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER},
  *     if present</li>
  *     <li>Encode slashes</li>
  *     <li>URI encoding</li>

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
@@ -8,7 +8,6 @@ import edu.illinois.library.cantaloupe.http.Method;
 import edu.illinois.library.cantaloupe.http.Reference;
 import edu.illinois.library.cantaloupe.http.Status;
 import edu.illinois.library.cantaloupe.image.Format;
-import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.util.StringUtils;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,7 +17,6 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,8 +32,6 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractResource {
 
-    public static final String PUBLIC_IDENTIFIER_HEADER = "X-Forwarded-ID";
-
     static final String RESPONSE_CONTENT_DISPOSITION_QUERY_ARG =
             "response-content-disposition";
 
@@ -44,15 +40,11 @@ public abstract class AbstractResource {
      */
     private DelegateProxy delegateProxy;
 
-    private List<String> pathArguments          = Collections.emptyList();
     private final RequestContext requestContext = new RequestContext();
     private Request request;
     private HttpServletResponse response;
 
-    /**
-     * Cached by {@link #getIdentifier()}.
-     */
-    private Identifier identifier;
+
 
     /**
      * Cached by {@link #getMetaIdentifier()}.
@@ -219,47 +211,7 @@ public abstract class AbstractResource {
         return delegateProxy;
     }
 
-    /**
-     * <p>Returns the decoded identifier path component of the URI. (This may
-     * not be the identifier that the client supplies or sees; for that, use
-     * {@link #getPublicIdentifier()}.)</p>
-     *
-     * <p>N.B.: Depending on the image request endpoint API, The return value
-     * may include "meta-information" that is not part of the identifier but is
-     * encoded along with it. In that case, it is not safe to consume via this
-     * method, and {@link #getMetaIdentifier()} should be used instead.</p>
-     *
-     * @return Identifier, or {@code null} if the URI does not have an
-     *         identifier path component.
-     * @see #getMetaIdentifier()
-     * @see #getPublicIdentifier()
-     */
-    protected Identifier getIdentifier() {
-        if (identifier == null) {
-            String pathComponent = getIdentifierPathComponent();
-            if (pathComponent != null) {
-                identifier = Identifier.fromURIPathComponent(pathComponent);
-            }
-        }
-        return identifier;
-    }
 
-    /**
-     * <p>Returns the first {@link #getPathArguments() path argument}. (Most
-     * resources have an identifier as the first path argument, so this will
-     * work for them, but if not, an override will be necessary.)</p>
-     *
-     * <p>The result is not decoded and may be a {@link MetaIdentifier
-     * meta-identifier}. As such, it is not usable without additional
-     * processing.</p>
-     *
-     * @return Identifier, or {@code null} if no path arguments are
-     *         available.
-     */
-    protected String getIdentifierPathComponent() {
-        List<String> args = getPathArguments();
-        return (!args.isEmpty()) ? args.get(0) : null;
-    }
 
     abstract protected Logger getLogger();
 
@@ -269,15 +221,15 @@ public abstract class AbstractResource {
      * component that the client supplies or sees; for that, use {@link
      * #getPublicIdentifier()}.)
      *
-     * @return Instance corresponding to the first {@link #getPathArguments()
+     * @return Instance corresponding to the first {@link Request#getPathArguments()
      *         path argument}, or {@code null} if no path arguments are
      *         available.
-     * @see #getIdentifier()
-     * @see #getPublicIdentifier()
+     * @see Request#getIdentifier()
+     * @see Request#getPublicIdentifier()
      */
     protected MetaIdentifier getMetaIdentifier() {
         if (metaIdentifier == null) {
-            String pathComponent = getIdentifierPathComponent();
+            String pathComponent = getRequest().getIdentifierPathComponent();
             if (pathComponent != null) {
                 metaIdentifier = MetaIdentifier.fromURIPathComponent(
                         pathComponent, getDelegateProxy());
@@ -287,15 +239,6 @@ public abstract class AbstractResource {
         return metaIdentifier;
     }
 
-    /**
-     * Returns the segments of the URI path that are considered arguments.
-     * (These may correspond to regex match groups in {@link Route}.)
-     *
-     * @return Path arguments, or an empty list if there are none.
-     */
-    protected final List<String> getPathArguments() {
-        return pathArguments;
-    }
 
     /**
      * @return List of client-preferred media types as expressed in the
@@ -307,24 +250,6 @@ public abstract class AbstractResource {
         ContentTypeNegotiator negotiator = new ContentTypeNegotiator(request.getHeaders());
         return negotiator.getPreferredMediaTypes();
     }
-
-    /**
-     * <p>Returns the identifier that the client sees. This will be the value
-     * of the {@link #PUBLIC_IDENTIFIER_HEADER} header, if available, or else
-     * the {@code identifier} URI path component.</p>
-     *
-     * <p>The result is not decoded, as the encoding may be influenced by
-     * {@link edu.illinois.library.cantaloupe.config.Key#SLASH_SUBSTITUTE}, for example.</p>
-     *
-     * @see #getIdentifier()
-     */
-    protected String getPublicIdentifier() {
-        return request.getHeaders().getFirstValue(
-                PUBLIC_IDENTIFIER_HEADER,
-                getIdentifierPathComponent());
-    }
-
-
 
     /**
      * <p>Returns a sanitized value for a {@code Content-Disposition} header
@@ -390,10 +315,6 @@ public abstract class AbstractResource {
         return new Method[] { Method.OPTIONS };
     }
 
-
-    final void setPathArguments(List<String> pathArguments) {
-        this.pathArguments = pathArguments;
-    }
 
     /**
      * @param request Request being handled.

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/HandlerServlet.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/HandlerServlet.java
@@ -76,8 +76,7 @@ public class HandlerServlet extends HttpServlet {
             }
 
             resource = route.getResource().getDeclaredConstructor().newInstance();
-            resource.setPathArguments(route.getPathArguments());
-            resource.setRequest(new Request(request));
+            resource.setRequest(new Request(request, route.getPathArguments()));
             resource.setResponse(response);
             resource.doInit();
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/Request.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/Request.java
@@ -6,6 +6,7 @@ import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
 import edu.illinois.library.cantaloupe.http.Headers;
 import edu.illinois.library.cantaloupe.http.Query;
 import edu.illinois.library.cantaloupe.http.Reference;
+import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,6 +27,12 @@ public final class Request {
     private HttpServletRequest wrappedRequest;
     private Headers headers;
     private Reference reference;
+    private List<String> pathArguments;
+
+    /**
+     * Cached by {@link #getIdentifier()}.
+     */
+    private Identifier identifier;
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Request.class);
@@ -40,12 +47,85 @@ public final class Request {
     /**
      * @param request Request that the new instance will wrap.
      */
-    Request(HttpServletRequest request) {
+    Request(HttpServletRequest request, List<String> pathArguments) {
         this.wrappedRequest = request;
+        this.pathArguments = pathArguments;
     }
 
     public String getContextPath() {
         return wrappedRequest.getContextPath();
+    }
+
+    /**
+     * Returns the segments of the URI path that are considered arguments.
+     * (These may correspond to regex match groups in {@link Route}.)
+     *
+     * @return Path arguments, or an empty list if there are none.
+     */
+    public final List<String> getPathArguments() {
+        return pathArguments;
+    }
+
+    /**
+     * <p>Returns the decoded identifier path component of the URI. (This may
+     * not be the identifier that the client supplies or sees; for that, use
+     * {@link #getPublicIdentifier()}.)</p>
+     *
+     * <p>N.B.: Depending on the image request endpoint API, The return value
+     * may include "meta-information" that is not part of the identifier but is
+     * encoded along with it. In that case, it is not safe to consume via this
+     * method, and {@link #getMetaIdentifier()} should be used instead.</p>
+     *
+     * @return Identifier, or {@code null} if the URI does not have an
+     *         identifier path component.
+     * @see #getMetaIdentifier()
+     * @see #getPublicIdentifier()
+     */
+    public Identifier getIdentifier() {
+        if (identifier == null) {
+            String pathComponent = getIdentifierPathComponent();
+            if (pathComponent != null) {
+                identifier = Identifier.fromURIPathComponent(pathComponent);
+            }
+        }
+        return identifier;
+    }
+
+    public static final String PUBLIC_IDENTIFIER_HEADER = "X-Forwarded-ID";
+
+
+    /**
+     * <p>Returns the identifier that the client sees. This will be the value
+     * of the {@link #PUBLIC_IDENTIFIER_HEADER} header, if available, or else
+     * the {@code identifier} URI path component.</p>
+     *
+     * <p>The result is not decoded, as the encoding may be influenced by
+     * {@link Key#SLASH_SUBSTITUTE}, for example.</p>
+     *
+     * @see #getIdentifier()
+     */
+    public String getPublicIdentifier() {
+        return getHeaders().getFirstValue(
+                PUBLIC_IDENTIFIER_HEADER,
+                getIdentifierPathComponent());
+    }
+
+
+    /**
+     * <p>Returns the first {@link #getPathArguments() path argument}. (Most
+     * resources have an identifier as the first path argument, so this will
+     * work for them, but if not, an override will be necessary.)</p>
+     *
+     * <p>The result is not decoded and may be a {@link MetaIdentifier
+     * meta-identifier}. As such, it is not usable without additional
+     * processing.</p>
+     *
+     * @return Identifier, or {@code null} if no path arguments are
+     *         available.
+     */
+    public String getIdentifierPathComponent() {
+        List<String> args = getPathArguments();
+        return (!args.isEmpty()) ? args.get(0) : null;
     }
 
     public Headers getHeaders() {

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/api/TaskResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/api/TaskResource.java
@@ -33,7 +33,7 @@ public class TaskResource extends AbstractAPIResource {
      * Writes a JSON task representation to the response output stream.
      */
     public void doGET() throws Exception {
-        final String uuidStr = getPathArguments().get(0);
+        final String uuidStr = getRequest().getPathArguments().get(0);
         try {
             final UUID uuid = UUID.fromString(uuidStr);
             APITask<?> task = TaskMonitor.getInstance().get(uuid);

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
@@ -152,7 +152,7 @@ public abstract class IIIFResource extends AbstractResource {
         if (newMetaId == null) {
             return false;
         }
-        Reference newRef = getRequest().getPublicReference(newMetaId, getIdentifierPathComponent(), getDelegateProxy());
+        Reference newRef = getRequest().getPublicReference(newMetaId, getRequest().getIdentifierPathComponent(), getDelegateProxy());
         getResponse().setStatus(301);
         getResponse().setHeader("Location", newRef.toString());
         new StringRepresentation("Redirect: " + newRef + "\n")
@@ -256,7 +256,7 @@ public abstract class IIIFResource extends AbstractResource {
                     .write(getResponse().getOutputStream());
             return false;
         } else if (metaIdentifier.getScaleConstraint() != null) {
-            Reference publicRef = getRequest().getPublicReference(metaIdentifier, getIdentifierPathComponent(), getDelegateProxy());
+            Reference publicRef = getRequest().getPublicReference(metaIdentifier, getRequest().getIdentifierPathComponent(), getDelegateProxy());
             getResponse().setStatus(code);
             getResponse().setHeader("Cache-Control", "no-cache");
             getResponse().setHeader("Location", publicRef.toString());

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/IdentifierResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/IdentifierResource.java
@@ -33,7 +33,7 @@ public class IdentifierResource extends IIIF1Resource {
         final Reference newRef = new Reference(
                 getRequest().getPublicRootReference() +
                 Route.IIIF_1_PATH +
-                "/" + getPublicIdentifier() +
+                "/" + getRequest().getPublicIdentifier() +
                 "/info.json");
         getResponse().setStatus(Status.SEE_OTHER.getCode());
         getResponse().setHeader("Location", newRef.toString(false));

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/ImageResource.java
@@ -140,7 +140,7 @@ public class ImageResource extends IIIF1Resource {
     }
 
     private OperationList getOperationList() {
-        final List<String> args = getPathArguments();
+        final List<String> args = getRequest().getPathArguments();
 
         // If the URI path contains a format extension, try to use that.
         // Otherwise, negotiate it based on the Accept header per Image API 1.1

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResource.java
@@ -134,12 +134,12 @@ public class InformationResource extends IIIF1Resource {
 
     /**
      * @return Image URI corresponding to the given identifier, respecting the
-     *         {@code X-Forwarded-*} and {@link #PUBLIC_IDENTIFIER_HEADER}
+     *         {@code X-Forwarded-*} and {@link Request#PUBLIC_IDENTIFIER_HEADER}
      *         reverse proxy headers.
      */
     private String getImageURI() {
         return getRequest().getPublicRootReference() + Route.IIIF_1_PATH + "/" +
-                getPublicIdentifier();
+                getRequest().getPublicIdentifier();
     }
 
     private String getNegotiatedMediaType() {

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/IdentifierResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/IdentifierResource.java
@@ -33,7 +33,7 @@ public class IdentifierResource extends IIIF2Resource {
         final Reference newRef = new Reference(
                 getRequest().getPublicRootReference() +
                 Route.IIIF_2_PATH +
-                "/" + getPublicIdentifier() +
+                "/" + getRequest().getPublicIdentifier() +
                 "/info.json");
         getResponse().setStatus(Status.SEE_OTHER.getCode());
         getResponse().setHeader("Location", newRef.toString(false));

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageResource.java
@@ -65,9 +65,9 @@ public class ImageResource extends IIIF2Resource {
         }
 
         // Assemble the URI path segments into a Parameters object.
-        final List<String> args = getPathArguments();
+        final List<String> args = getRequest().getPathArguments();
         final Parameters params = new Parameters(
-                getIdentifier().toString(), args.get(1), args.get(2),
+                getRequest().getIdentifier().toString(), args.get(1), args.get(2),
                 args.get(3), args.get(4), args.get(5));
         // Convert it into an OperationList.
         final OperationList ops = params.toOperationList(getDelegateProxy());
@@ -162,7 +162,7 @@ public class ImageResource extends IIIF2Resource {
                 params.getOutputFormat().toFormat().getPreferredMediaType().toString());
         // Link
         Parameters paramsCopy = new Parameters(params);
-        paramsCopy.setIdentifier(getPublicIdentifier());
+        paramsCopy.setIdentifier(getRequest().getPublicIdentifier());
         String paramsStr = paramsCopy.toCanonicalString(fullSize);
         queuedHeaders.put("Link",
                 String.format("<%s%s/%s>;rel=\"canonical\"",

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResource.java
@@ -131,12 +131,12 @@ public class InformationResource extends IIIF2Resource {
 
     /**
      * @return Image URI corresponding to the given identifier, respecting the
-     *         {@code X-Forwarded-*} and {@link #PUBLIC_IDENTIFIER_HEADER}
+     *         {@code X-Forwarded-*} and {@link Request#PUBLIC_IDENTIFIER_HEADER}
      *         reverse proxy headers.
      */
     private String getImageURI() {
         return getRequest().getPublicRootReference() + Route.IIIF_2_PATH + "/" +
-                getPublicIdentifier();
+                getRequest().getPublicIdentifier();
     }
 
     private String getNegotiatedMediaType() {

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/IdentifierResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/IdentifierResource.java
@@ -33,7 +33,7 @@ public class IdentifierResource extends IIIF3Resource {
         final Reference newRef = new Reference(
                 getRequest().getPublicRootReference() +
                 Route.IIIF_3_PATH +
-                "/" + getPublicIdentifier() +
+                "/" + getRequest().getPublicIdentifier() +
                 "/info.json");
         getResponse().setStatus(Status.SEE_OTHER.getCode());
         getResponse().setHeader("Location", newRef.toString(false));

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
@@ -67,9 +67,9 @@ public class ImageResource extends IIIF3Resource {
         }
 
         // Assemble the URI path segments into a Parameters object.
-        final List<String> args = getPathArguments();
+        final List<String> args = getRequest().getPathArguments();
         final Parameters params = new Parameters(
-                getIdentifier().toString(), args.get(1), args.get(2),
+                getRequest().getIdentifier().toString(), args.get(1), args.get(2),
                 args.get(3), args.get(4), args.get(5));
         // Convert it into an OperationList.
         final OperationList ops = params.toOperationList(
@@ -162,7 +162,7 @@ public class ImageResource extends IIIF3Resource {
                 params.getOutputFormat().toFormat().getPreferredMediaType().toString());
         // Link
         Parameters paramsCopy = new Parameters(params);
-        paramsCopy.setIdentifier(getPublicIdentifier());
+        paramsCopy.setIdentifier(getRequest().getPublicIdentifier());
         String paramsStr = paramsCopy.toCanonicalString(fullSize);
         queuedHeaders.put("Link",
                 String.format("<%s%s/%s>;rel=\"canonical\"",

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResource.java
@@ -1,5 +1,21 @@
 package edu.illinois.library.cantaloupe.resource.iiif.v3;
 
+import edu.illinois.library.cantaloupe.http.Method;
+import edu.illinois.library.cantaloupe.http.Status;
+import edu.illinois.library.cantaloupe.image.Format;
+import edu.illinois.library.cantaloupe.image.Info;
+import edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactory;
+import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
+import edu.illinois.library.cantaloupe.resource.JacksonRepresentation;
+import edu.illinois.library.cantaloupe.resource.ResourceException;
+import edu.illinois.library.cantaloupe.resource.Route;
+import edu.illinois.library.cantaloupe.source.StatResult;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.script.ScriptException;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -7,22 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import edu.illinois.library.cantaloupe.http.Method;
-import edu.illinois.library.cantaloupe.http.Status;
-import edu.illinois.library.cantaloupe.image.Format;
-import edu.illinois.library.cantaloupe.image.Info;
-import edu.illinois.library.cantaloupe.processor.codec.ImageWriterFactory;
-import edu.illinois.library.cantaloupe.resource.JacksonRepresentation;
-import edu.illinois.library.cantaloupe.resource.ResourceException;
-import edu.illinois.library.cantaloupe.resource.Route;
-import edu.illinois.library.cantaloupe.resource.InformationRequestHandler;
-import edu.illinois.library.cantaloupe.source.StatResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.script.ScriptException;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Handles IIIF Image API 3.x information requests.
@@ -136,7 +136,7 @@ public class InformationResource extends IIIF3Resource {
      */
     private String getImageURI() {
         return getRequest().getPublicRootReference() + Route.IIIF_3_PATH + "/" +
-                getPublicIdentifier();
+                getRequest().getPublicIdentifier();
     }
 
     private String getNegotiatedContentType() {

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/AbstractResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/AbstractResourceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,7 +29,7 @@ public class AbstractResourceTest extends BaseTest {
             }
         };
 
-        Request mockRequest = new Request(new MockHttpServletRequest());
+        Request mockRequest = new Request(new MockHttpServletRequest(), Collections.emptyList());
         instance.setRequest(mockRequest);
         instance.setResponse(new MockHttpServletResponse());
     }

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextDecoratorTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/RequestContextDecoratorTest.java
@@ -1,11 +1,11 @@
 package edu.illinois.library.cantaloupe.resource;
+import edu.illinois.library.cantaloupe.http.Cookies;
 import org.junit.jupiter.api.Test;
 
-import edu.illinois.library.cantaloupe.http.Cookies;
-
-import static org.junit.jupiter.api.Assertions.*;
-
+import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RequestContextDecoratorTest {
     @Test
@@ -13,7 +13,7 @@ public class RequestContextDecoratorTest {
         MockHttpServletRequest sr = new MockHttpServletRequest();
         sr.getHeaders().put("Cookie", List.of("fruit=apples; animal=cats",
                 "shape=cube; car=ford"));
-        Request instance = new Request(sr);
+        Request instance = new Request(sr, Collections.emptyList());
 
         Cookies cookies = RequestContextDecorator.getCookies(instance);
         assertEquals(4, cookies.size());

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/RequestTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/RequestTest.java
@@ -2,37 +2,34 @@ package edu.illinois.library.cantaloupe.resource;
 
 import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
-import edu.illinois.library.cantaloupe.http.Cookies;
 import edu.illinois.library.cantaloupe.http.Headers;
-import edu.illinois.library.cantaloupe.http.Method;
 import edu.illinois.library.cantaloupe.http.Reference;
 import edu.illinois.library.cantaloupe.test.BaseTest;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class RequestTest extends BaseTest {
 
-    private Request instance;
+    private MockHttpServletRequest sr = new MockHttpServletRequest();
+    private Request instance = new Request(sr, Collections.emptyList());
 
     @Test
     void testGetContextPath() {
         final String path = "/the-new-path";
-        MockHttpServletRequest sr = new MockHttpServletRequest();
         sr.setContextPath(path);
-        instance = new Request(sr);
         assertEquals(path, instance.getContextPath());
     }
 
     @Test
     void testGetHeaders() {
-        MockHttpServletRequest sr = new MockHttpServletRequest();
         sr.getHeaders().put("Cookie", List.of("cats=yes"));
         sr.getHeaders().put("Accept", List.of("text/plain"));
-        instance = new Request(sr);
 
         Headers headers = instance.getHeaders();
         assertEquals(2, headers.size());
@@ -48,9 +45,7 @@ class RequestTest extends BaseTest {
     @Test
     void testGetReference() {
         String url = "http://example.org/cats?query=yes";
-        MockHttpServletRequest sr = new MockHttpServletRequest();
         sr.setRequestURL(url);
-        instance = new Request(sr);
 
         assertEquals(new Reference(url), instance.getReference());
     }
@@ -58,18 +53,13 @@ class RequestTest extends BaseTest {
     @Test
     void testGetRemoteAddr() {
         String addr = "10.2.5.3";
-        MockHttpServletRequest sr = new MockHttpServletRequest();
         sr.setRemoteAddr(addr);
-        instance = new Request(sr);
 
         assertEquals(addr, instance.getRemoteAddr());
     }
 
     @Test
     void testGetServletRequest() {
-        MockHttpServletRequest sr = new MockHttpServletRequest();
-        instance = new Request(sr);
-
         assertSame(sr, instance.getServletRequest());
     }
 
@@ -87,7 +77,7 @@ class RequestTest extends BaseTest {
         servletRequest.setContextPath("/base");
         servletRequest.setRequestURL("http://example.org/base/llamas");
 
-        instance = new Request(servletRequest);
+        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(baseURI + "/llamas", ref.toString());
     }
@@ -106,7 +96,7 @@ class RequestTest extends BaseTest {
         servletRequest.setContextPath("");
         servletRequest.setRequestURL("http://bogus/cats");
 
-        instance = new Request(servletRequest);
+        instance = new Request(servletRequest, Collections.emptyList());
         Headers headers = instance.getHeaders();
         headers.set("X-Forwarded-Proto", "HTTP");
         headers.set("X-Forwarded-Host", "example.org");
@@ -128,7 +118,7 @@ class RequestTest extends BaseTest {
         servletRequest.setContextPath("/cats");
         servletRequest.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest);
+        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(resourceURI, ref.toString());
     }
@@ -145,7 +135,7 @@ class RequestTest extends BaseTest {
         servletRequest.setContextPath("/cats");
         servletRequest.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest);
+        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(resourceURI, ref.toString());
     }
@@ -159,7 +149,7 @@ class RequestTest extends BaseTest {
         servletRequest.setContextPath("/cats");
         servletRequest.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest);
+        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(expected, ref.toString());
     }

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/TemplateVariablesTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/TemplateVariablesTest.java
@@ -9,7 +9,7 @@ public class TemplateVariablesTest {
     
     @Test
     void testGetCommonTemplateVars() {
-        Request request = new Request(new MockHttpServletRequest());
+        Request request = new Request(new MockHttpServletRequest(), java.util.Collections.emptyList());
         TemplateVariables vars = TemplateVariables.getDefault(request);
         assertEquals(((String) vars.get("basePath")), "/");
         assertNotNull(vars.get("version"));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
@@ -9,8 +9,8 @@ import edu.illinois.library.cantaloupe.http.Client;
 import edu.illinois.library.cantaloupe.http.ResourceException;
 import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
-import edu.illinois.library.cantaloupe.resource.AbstractResource;
 import edu.illinois.library.cantaloupe.test.TestUtil;
+import edu.illinois.library.cantaloupe.resource.Request;
 
 import java.io.File;
 import java.net.URI;
@@ -400,7 +400,7 @@ public class InformationResourceTester extends ImageAPIResourceTester {
     public void testRedirectToInfoJSONWithDifferentPublicIdentifier(URI uri)
             throws Exception {
         Client client = newClient(uri);
-        client.getHeaders().set(AbstractResource.PUBLIC_IDENTIFIER_HEADER, "foxes");
+        client.getHeaders().set(Request.PUBLIC_IDENTIFIER_HEADER, "foxes");
         try {
             Response response = client.send();
             assertEquals(303, response.getStatus());

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.AbstractResource;
+import edu.illinois.library.cantaloupe.resource.Request;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -511,7 +511,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                AbstractResource.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.AbstractResource;
+import edu.illinois.library.cantaloupe.resource.Request;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -533,7 +533,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                AbstractResource.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.AbstractResource;
+import edu.illinois.library.cantaloupe.resource.Request;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -510,7 +510,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                AbstractResource.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();


### PR DESCRIPTION
Move them out of the AbstractResource. An AbstractResource is something that is on the server, but these methods are about something in the user's Request.  These are fundamentally different objects.
Ref #848