### PR TITLE
Use host relative paths for static resources

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
@@ -223,17 +223,9 @@ public abstract class AbstractResource {
     protected final Map<String, Object> getCommonTemplateVars() {
         final Map<String,Object> vars = new HashMap<>();
         vars.put("version", Application.getVersion());
-        try {
-            String baseURI = getRequest().getPublicRootReference().toString();
-            // Normalize the base URI. Note that the <base> tag will need it to
-            // have a trailing slash.
-            if (baseURI.endsWith("/")) {
-                baseURI = baseURI.substring(0, baseURI.length() - 2);
-            }
-            vars.put("baseUri", baseURI);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalClientArgumentException(e);
-        }
+        vars.put("basePath", getRequest().
+                                 getHeaders().
+                                 getFirstValue("X-Forwarded-Path", "/"));
         return vars;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/admin/AdminResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/admin/AdminResource.java
@@ -17,6 +17,7 @@ import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.ThymeleafRepresentation;
 import edu.illinois.library.cantaloupe.source.Source;
 import edu.illinois.library.cantaloupe.source.SourceFactory;
+import edu.illinois.library.cantaloupe.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -154,7 +155,7 @@ public class AdminResource extends AbstractAdminResource {
      */
     private Map<String,Object> getTemplateVars() {
         final Map<String, Object> vars = getCommonTemplateVars();
-        vars.put("adminUri", vars.get("baseUri") + Route.ADMIN_PATH);
+        vars.put("adminUri", StringUtils.stripEnd((String) vars.get("basePath"), "/") + Route.ADMIN_PATH);
 
         ////////////////////////////////////////////////////////////////////
         //////////////////////// status section ////////////////////////////

--- a/src/main/resources/admin.html
+++ b/src/main/resources/admin.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <base th:if="${baseUri}" th:href="${baseUri + '/'}">
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="static/styles/admin.css">
+    <link rel="stylesheet" th:href="${basePath + 'static/styles/admin.css'}">
 
     <title>Cantaloupe Image Server</title>
 </head>
@@ -19,7 +18,7 @@
 <div class="container-fluid">
     <div class="clearfix">
         <header>
-            <img src="static/images/cantaloupe-320.png" alt="Cantaloupe icon"
+            <img th:src="${basePath + 'static/images/cantaloupe-320.png'}" alt="Cantaloupe icon"
                  width="154" height="82" style="float:left">
             <h1>Cantaloupe Image Server <small th:text="${version}"></small></h1>
         </header>

--- a/src/main/resources/head_common.html
+++ b/src/main/resources/head_common.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="head">
-    <base th:if="${baseUri}" th:href="${baseUri + '/'}">
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="static/styles/base.css">
+    <link rel="stylesheet" th:href="${basePath + 'static/styles/base.css'}">
 </head>
 </html>

--- a/src/main/resources/iiif_1_landing.html
+++ b/src/main/resources/iiif_1_landing.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <base th:if="${baseUri}" th:href="${baseUri + '/'}">
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="static/styles/base.css">
+    <link rel="stylesheet" th:href="${basePath + 'static/styles/base.css'}">
 
     <title>Cantaloupe Image Server</title>
 </head>
@@ -25,14 +24,14 @@
             </li>
             <li>Sample Requests
                 <ul>
-                    <li th:text="${baseUri + '/iiif/1/{identifier}/info.json'}"></li>
-                    <li th:text="${baseUri + '/iiif/1/{identifier}/full/full/0/native.jpg'}"></li>
+                    <li th:text="${basePath + 'iiif/1/{identifier}/info.json'}"></li>
+                    <li th:text="${basePath + 'iiif/1/{identifier}/full/full/0/native.jpg'}"></li>
                 </ul>
             </li>
             <li>Also Available:
                 <ul>
-                    <li><a th:href="${baseUri + '/iiif/2'}">IIIF Image API 2.x endpoint</a></li>
-                    <li><a th:href="${baseUri + '/iiif/3'}">IIIF Image API 3.x endpoint</a></li>
+                    <li><a th:href="${basePath + 'iiif/2'}">IIIF Image API 2.x endpoint</a></li>
+                    <li><a th:href="${basePath + 'iiif/3'}">IIIF Image API 3.x endpoint</a></li>
                 </ul>
             </li>
         </ul>

--- a/src/main/resources/iiif_2_landing.html
+++ b/src/main/resources/iiif_2_landing.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <base th:if="${baseUri}" th:href="${baseUri + '/'}">
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="static/styles/base.css">
+    <link rel="stylesheet" th:href="${basePath + 'static/styles/base.css'}">
 
     <title>Cantaloupe Image Server</title>
 </head>
@@ -25,14 +24,14 @@
             </li>
             <li>Sample Requests
                 <ul>
-                    <li th:text="${baseUri + '/iiif/2/{identifier}/info.json'}"></li>
-                    <li th:text="${baseUri + '/iiif/2/{identifier}/full/full/0/default.jpg'}"></li>
+                    <li th:text="${basePath + 'iiif/2/{identifier}/info.json'}"></li>
+                    <li th:text="${basePath + 'iiif/2/{identifier}/full/full/0/default.jpg'}"></li>
                 </ul>
             </li>
             <li>Also Available:
                 <ul>
-                    <li><a th:href="${baseUri + '/iiif/1'}">IIIF Image API 1.x endpoint</a></li>
-                    <li><a th:href="${baseUri + '/iiif/3'}">IIIF Image API 3.x endpoint</a></li>
+                    <li><a th:href="${basePath + 'iiif/1'}">IIIF Image API 1.x endpoint</a></li>
+                    <li><a th:href="${basePath + 'iiif/3'}">IIIF Image API 3.x endpoint</a></li>
                 </ul>
             </li>
         </ul>

--- a/src/main/resources/iiif_3_landing.html
+++ b/src/main/resources/iiif_3_landing.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
     <head>
-        <base th:if="${baseUri}" th:href="${baseUri + '/'}">
         <meta charset="utf-8">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <link rel="stylesheet" href="static/styles/base.css">
+        <link rel="stylesheet" th:href="${basePath + 'static/styles/base.css'}">
 
         <title>Cantaloupe Image Server</title>
     </head>
@@ -24,14 +23,14 @@
                 </li>
                 <li>Sample Requests
                     <ul>
-                        <li th:text="${baseUri + '/iiif/3/{identifier}/info.json'}"></li>
-                        <li th:text="${baseUri + '/iiif/3/{identifier}/full/max/0/default.jpg'}"></li>
+                        <li th:text="${basePath + 'iiif/3/{identifier}/info.json'}"></li>
+                        <li th:text="${basePath + 'iiif/3/{identifier}/full/max/0/default.jpg'}"></li>
                     </ul>
                 </li>
                 <li>Also Available:
                     <ul>
-                        <li><a th:href="${baseUri + '/iiif/1'}">IIIF Image API 1.x endpoint</a></li>
-                        <li><a th:href="${baseUri + '/iiif/2'}">IIIF Image API 2.x endpoint</a></li>
+                        <li><a th:href="${basePath + 'iiif/1'}">IIIF Image API 1.x endpoint</a></li>
+                        <li><a th:href="${basePath + 'iiif/2'}">IIIF Image API 2.x endpoint</a></li>
                     </ul>
                 </li>
             </ul>

--- a/src/main/resources/landing.html
+++ b/src/main/resources/landing.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <base th:if="${baseUri}" th:href="${baseUri + '/'}">
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="static/styles/landing.css">
+    <link rel="stylesheet" th:href="${basePath + 'static/styles/landing.css'}">
 
     <title>Cantaloupe Image Server</title>
 </head>
 
 <body>
     <div id="container">
-        <img src="static/images/cantaloupe-320.png" width="320" alt="Logo">
+        <img th:src="${basePath + 'static/images/cantaloupe-320.png'}" width="320" alt="Logo">
         <h1>Cantaloupe Image Server <small th:text="${version}"></small></h1>
     </div>
 </body>

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/AbstractResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/AbstractResourceTest.java
@@ -75,7 +75,7 @@ public class AbstractResourceTest extends BaseTest {
     @Test
     void testGetCommonTemplateVars() {
         Map<String,Object> vars = instance.getCommonTemplateVars();
-        assertFalse(((String) vars.get("baseUri")).endsWith("/"));
+        assertEquals(((String) vars.get("basePath")), "/");
         assertNotNull(vars.get("version"));
     }
 


### PR DESCRIPTION
This makes the proxy configuration simpler, as we're no longer depending on host, protocol and port for every static resource. Previously, if you were using a proxy, but didn't set X-Forwared-Port, static resources wouldn't load as it would use the Jetty port.