### PR TITLE
Make OperationList.applyNonEndpointMutations idempotent

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -110,6 +110,7 @@ public final class OperationList implements Iterable<Operation> {
             LoggerFactory.getLogger(OperationList.class);
 
     private boolean isFrozen;
+    private boolean haveAppliedNonEndpointMutations;
     private Identifier identifier;
     private MetaIdentifier metaIdentifier;
     private final List<Operation> operations = new ArrayList<>();
@@ -221,12 +222,29 @@ public final class OperationList implements Iterable<Operation> {
      * <p>The instance's identifier must be {@link #setIdentifier(Identifier)
      * set}.</p>
      *
+     * <p>This method is idempotent: subsequent calls on the same instance are
+     * no-ops. Several of the mutations append operations unconditionally, so
+     * repeated invocations would otherwise stack duplicate redactions, sharpen
+     * passes, and overlays on the same list.</p>
+     *
      * @param info          Source image info.
      * @param delegateProxy Delegate proxy for the current request.
      */
     public void applyNonEndpointMutations(final Info info,
                                           final DelegateProxy delegateProxy) {
         checkFrozen();
+        // Several mutations below (Redaction, Sharpen, Overlay) call
+        // addBefore() without checking whether an equivalent operation is
+        // already present, so calling this method more than once on the same
+        // instance would append duplicates. ImageRequestHandler.handle()
+        // legitimately needs to call this twice in the cache-miss path (once
+        // to form the derivative cache key, once after the request context is
+        // fully populated), so guard against the second call here rather than
+        // requiring every caller to track state.
+        if (haveAppliedNonEndpointMutations) {
+            return;
+        }
+        haveAppliedNonEndpointMutations = true;
 
         // If there is a scale constraint set, but no Scale operation, add one.
         if (getScaleConstraint().hasEffect()) {

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
@@ -403,6 +403,39 @@ class OperationListTest extends BaseTest {
     }
 
     @Test
+    void applyNonEndpointMutationsIsIdempotent() {
+        BasicStringOverlayServiceTest.setUpConfiguration();
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.PROCESSOR_SHARPEN, 0.5);
+
+        final Dimension fullSize   = new Dimension(2000, 1000);
+        final Info info            = Info.builder().withSize(fullSize).build();
+        final OperationList opList = OperationList.builder()
+                .withIdentifier(new Identifier("redacted"))
+                .withOperations(new Encode(Format.get("tif")))
+                .build();
+
+        DelegateProxy proxy = TestUtil.newDelegateProxy();
+        proxy.getRequestContext().setOperationList(opList, fullSize);
+
+        opList.applyNonEndpointMutations(info, proxy);
+        opList.applyNonEndpointMutations(info, proxy);
+
+        long overlays = opList.stream()
+                .filter(op -> op instanceof Overlay).count();
+        long redactions = opList.stream()
+                .filter(op -> op instanceof Redaction).count();
+        long sharpens = opList.stream()
+                .filter(op -> op instanceof Sharpen).count();
+        assertEquals(1, overlays,
+                "overlay should be appended exactly once");
+        assertEquals(1, redactions,
+                "redaction should be appended exactly once");
+        assertEquals(1, sharpens,
+                "sharpen should be appended exactly once");
+    }
+
+    @Test
     void applyNonEndpointMutationsWithRedactions() {
         final Dimension fullSize   = new Dimension(2000, 1000);
         final Info info            = Info.builder().withSize(fullSize).build();


### PR DESCRIPTION
Fixes #947.

## Problem

`ImageRequestHandler.handle()` calls `OperationList.applyNonEndpointMutations()` twice on the same `OperationList` instance in the cache-miss path (once at line 316 to form the derivative cache key, once at line 405 after the request context is fully populated). Several mutations inside `applyNonEndpointMutations` append operations via `addBefore` without checking whether an equivalent operation is already present:

- Redactions (one `addBefore` per redaction returned by the delegate)
- Sharpen (when `processor.sharpen > 0`)
- Overlay (when overlays are enabled)

So the second invocation appends a duplicate of each. With the Basic overlay strategy this surfaces as a visibly denser watermark and a ~30% per-tile processing penalty on every cache miss. See #947 for byte-level reproduction.

## Fix

Add a single-shot flag (`haveAppliedNonEndpointMutations`) to `OperationList`. The method is now idempotent: subsequent invocations return immediately. This keeps the existing two-call structure in `ImageRequestHandler` intact - the first call is still needed to populate the cache key before the derivative cache lookup - and protects future callers from the same trap.

I considered tracking the state at the caller (in `ImageRequestHandler.handle()`) instead, but the defensive form is harder to regress.

## Test

Added `OperationListTest#applyNonEndpointMutationsIsIdempotent`: configures Basic overlay + non-trivial sharpen + delegate redactions, calls `applyNonEndpointMutations` twice on the same list, asserts overlay/redaction/sharpen each appear exactly once.

## Test plan

- [x] `mvn -Dtest=OperationListTest test` - all 85 existing tests still pass plus the new idempotency assertion
- [x] `mvn -Dtest=ImageRequestHandlerTest test` - all 14 existing handler tests pass with no change
- [x] Manual reproduction from #947 verified: the duplicate `imageoverlay:` segment disappears from the debug operation-list log after the fix, and the rendered tile byte stream matches the single-overlay reference (`md5 ae23796bc0...`).