### PR TITLE
Copy the operationsList before modifying it

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/ColorTransform.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/ColorTransform.java
@@ -13,6 +13,14 @@ public enum ColorTransform implements Operation {
     BITONAL, GRAY;
 
     /**
+     * @return The instance itself, as it is immutable.
+     */
+    @Override
+    public Operation copy() {
+        return this;
+    }
+
+    /**
      * Does nothing.
      */
     @Override

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/CropByPercent.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/CropByPercent.java
@@ -31,6 +31,13 @@ public class CropByPercent extends Crop implements Operation {
         setHeight(height);
     }
 
+    @Override
+    public CropByPercent copy() {
+        CropByPercent copy = new CropByPercent(x, y, width, height);
+        copy.orientation = orientation;
+        return copy;
+    }
+
     /**
      * @return The X origin of the operation, expressed in percent.
      */

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/CropByPixels.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/CropByPixels.java
@@ -24,6 +24,13 @@ public class CropByPixels extends Crop implements Operation {
         setHeight(height);
     }
 
+    @Override
+    public CropByPixels copy() {
+        CropByPixels copy = new CropByPixels(x, y, width, height);
+        copy.orientation = orientation;
+        return copy;
+    }
+
     /**
      * @return The X origin of the operation, expressed in pixels.
      */

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/CropToSquare.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/CropToSquare.java
@@ -7,6 +7,13 @@ import edu.illinois.library.cantaloupe.image.ScaleConstraint;
 public class CropToSquare extends Crop implements Operation {
 
     @Override
+    public CropToSquare copy() {
+        CropToSquare copy = new CropToSquare();
+        copy.orientation = orientation;
+        return copy;
+    }
+
+    @Override
     public Rectangle getRectangle(Dimension reducedSize,
                                   ReductionFactor reductionFactor,
                                   ScaleConstraint scaleConstraint) {

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Encode.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Encode.java
@@ -36,6 +36,20 @@ public class Encode implements Operation {
     }
 
     @Override
+    public Encode copy() {
+        Encode copy = new Encode(format);
+        copy.setBackgroundColor(backgroundColor);
+        copy.setCompression(compression);
+        copy.setInterlacing(interlace);
+        copy.setMaxComponentSize(maxComponentSize);
+        copy.setQuality(quality);
+        // Metadata is only ever replaced wholesale (never mutated in place) by
+        // the operation pipeline, so sharing the reference is safe.
+        copy.setMetadata(metadata);
+        return copy;
+    }
+
+    @Override
     public void freeze() {
         isFrozen = true;
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Operation.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Operation.java
@@ -12,6 +12,17 @@ import java.util.Map;
 public interface Operation {
 
     /**
+     * <p>Returns a deep copy of the instance. The copy is never frozen, even
+     * if the instance it was copied from is, so that it can be safely
+     * mutated.</p>
+     *
+     * <p>Immutable operations (such as enums) may return themselves.</p>
+     *
+     * @return Deep copy of the instance.
+     */
+    Operation copy();
+
+    /**
      * Freezes the instance, making it immutable. When frozen, mutation methods
      * should throw an {@link IllegalStateException} and getters should return
      * immutable values, if possible. (But they should do that anyway.)

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -828,8 +828,13 @@ public final class OperationList implements Iterable<Operation> {
     }
 
     /**
-     * Creates a shallow copy of this OperationList with the same operations,
-     * options, identifier, and page index.
+     * <p>Creates a deep copy of this instance with the same identifier, page
+     * index, options, and operations.</p>
+     *
+     * <p>Each {@link Operation} is itself {@link Operation#copy() copied}, so
+     * that mutating an operation in the copy (as {@link
+     * #applyNonEndpointMutations} does) does not affect the corresponding
+     * operation in this instance. The returned copy is never frozen.</p>
      *
      * @return A new OperationList with the same state as this instance.
      */
@@ -838,7 +843,9 @@ public final class OperationList implements Iterable<Operation> {
         copy.identifier = this.identifier;
         copy.metaIdentifier = this.metaIdentifier;
         copy.pageIndex = this.pageIndex;
-        copy.operations.addAll(this.operations);
+        for (Operation op : this.operations) {
+            copy.operations.add(op.copy());
+        }
         copy.options.putAll(this.options);
         return copy;
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/OperationList.java
@@ -2,6 +2,7 @@ package edu.illinois.library.cantaloupe.operation;
 
 import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
 import edu.illinois.library.cantaloupe.image.Compression;
 import edu.illinois.library.cantaloupe.image.Dimension;
 import edu.illinois.library.cantaloupe.image.Format;
@@ -15,7 +16,6 @@ import edu.illinois.library.cantaloupe.operation.overlay.Overlay;
 import edu.illinois.library.cantaloupe.operation.overlay.OverlayFactory;
 import edu.illinois.library.cantaloupe.operation.redaction.Redaction;
 import edu.illinois.library.cantaloupe.operation.redaction.RedactionService;
-import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
 import edu.illinois.library.cantaloupe.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -825,6 +825,22 @@ public final class OperationList implements Iterable<Operation> {
                 resultingSize.area() > maxAllowedSize) {
             throw new IllegalSizeException();
         }
+    }
+
+    /**
+     * Creates a shallow copy of this OperationList with the same operations,
+     * options, identifier, and page index.
+     *
+     * @return A new OperationList with the same state as this instance.
+     */
+    public OperationList copy() {
+        OperationList copy = new OperationList();
+        copy.identifier = this.identifier;
+        copy.metaIdentifier = this.metaIdentifier;
+        copy.pageIndex = this.pageIndex;
+        copy.operations.addAll(this.operations);
+        copy.options.putAll(this.options);
+        return copy;
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Rotate.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Rotate.java
@@ -29,6 +29,11 @@ public class Rotate implements Operation {
         setDegrees(degrees);
     }
 
+    @Override
+    public Rotate copy() {
+        return new Rotate(degrees);
+    }
+
     /**
      * @param degrees Degrees to add.
      * @throws IllegalStateException if the instance is frozen.

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Scale.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Scale.java
@@ -38,6 +38,14 @@ public abstract class Scale implements Operation {
         }
 
         /**
+         * @return The instance itself, as it is immutable.
+         */
+        @Override
+        public Operation copy() {
+            return this;
+        }
+
+        /**
          * Does nothing.
          */
         @Override

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPercent.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPercent.java
@@ -34,6 +34,14 @@ public class ScaleByPercent extends Scale implements Operation {
     }
 
     @Override
+    public ScaleByPercent copy() {
+        ScaleByPercent copy = new ScaleByPercent(percent);
+        copy.setFilter(getFilter());
+        copy.setLinear(isLinear());
+        return copy;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPixels.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPixels.java
@@ -61,6 +61,14 @@ public class ScaleByPixels extends Scale implements Operation {
     }
 
     @Override
+    public ScaleByPixels copy() {
+        ScaleByPixels copy = new ScaleByPixels(width, height, scaleMode);
+        copy.setFilter(getFilter());
+        copy.setLinear(isLinear());
+        return copy;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Sharpen.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Sharpen.java
@@ -25,6 +25,11 @@ public class Sharpen implements Operation {
     }
 
     @Override
+    public Sharpen copy() {
+        return new Sharpen(amount);
+    }
+
+    @Override
     public void freeze() {
         isFrozen = true;
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Transpose.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Transpose.java
@@ -16,6 +16,14 @@ public enum Transpose implements Operation {
     VERTICAL;
 
     /**
+     * @return The instance itself, as it is immutable.
+     */
+    @Override
+    public Operation copy() {
+        return this;
+    }
+
+    /**
      * Does nothing.
      */
     @Override

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/ImageOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/ImageOverlay.java
@@ -38,6 +38,11 @@ public class ImageOverlay extends Overlay implements Operation {
         setURI(uri);
     }
 
+    @Override
+    public ImageOverlay copy() {
+        return new ImageOverlay(uri, getPosition(), getInset());
+    }
+
     /**
      * For reading the image, clients should use {@link #openStream()} instead.
      *

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
@@ -49,6 +49,13 @@ public class StringOverlay extends Overlay implements Operation {
         this.setWordWrap(wordWrap);
     }
 
+    @Override
+    public StringOverlay copy() {
+        return new StringOverlay(string, getPosition(), getInset(), font,
+                minSize, color, backgroundColor, strokeColor, strokeWidth,
+                wordWrap);
+    }
+
     public Color getBackgroundColor() {
         return backgroundColor;
     }

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/redaction/Redaction.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/redaction/Redaction.java
@@ -30,6 +30,11 @@ public class Redaction implements Operation {
     }
 
     @Override
+    public Redaction copy() {
+        return new Redaction((region != null) ? new Rectangle(region) : null);
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/ImageRequestHandler.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/ImageRequestHandler.java
@@ -4,6 +4,7 @@ import edu.illinois.library.cantaloupe.async.TaskQueue;
 import edu.illinois.library.cantaloupe.cache.CacheFacade;
 import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
 import edu.illinois.library.cantaloupe.image.Dimension;
 import edu.illinois.library.cantaloupe.image.Format;
 import edu.illinois.library.cantaloupe.image.Identifier;
@@ -14,11 +15,10 @@ import edu.illinois.library.cantaloupe.processor.Processor;
 import edu.illinois.library.cantaloupe.processor.ProcessorConnector;
 import edu.illinois.library.cantaloupe.processor.ProcessorFactory;
 import edu.illinois.library.cantaloupe.processor.SourceFormatException;
-import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
-import edu.illinois.library.cantaloupe.source.StatResult;
-import edu.illinois.library.cantaloupe.status.HealthChecker;
 import edu.illinois.library.cantaloupe.source.Source;
 import edu.illinois.library.cantaloupe.source.SourceFactory;
+import edu.illinois.library.cantaloupe.source.StatResult;
+import edu.illinois.library.cantaloupe.status.HealthChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,11 +313,14 @@ public class ImageRequestHandler extends AbstractRequestHandler
             final Optional<Info> optInfo = cacheFacade.getInfo(identifier);
             if (optInfo.isPresent()) {
                 Info info = optInfo.get();
-                operationList.applyNonEndpointMutations(info, delegateProxy);
+                // Use a copy of operationList for cache lookup to avoid mutations
+                // persisting if no cached image is found.
+                OperationList cacheOpList = operationList.copy();
+                cacheOpList.applyNonEndpointMutations(info, delegateProxy);
 
                 InputStream cacheStream = null;
                 try {
-                    cacheStream = cacheFacade.newDerivativeImageInputStream(operationList);
+                    cacheStream = cacheFacade.newDerivativeImageInputStream(cacheOpList);
                 } catch (IOException e) {
                     // Don't rethrow -- it's still possible to service the
                     // request.

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/MockOverlay.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/MockOverlay.java
@@ -15,6 +15,11 @@ public class MockOverlay extends Overlay {
     }
 
     @Override
+    public MockOverlay copy() {
+        return new MockOverlay();
+    }
+
+    @Override
     public Map<String, Object> toMap(Dimension fullSize,
                                      ScaleConstraint scaleConstraint) {
         return new HashMap<>();

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/OperationListTest.java
@@ -1105,4 +1105,99 @@ class OperationListTest extends BaseTest {
                 () -> ops.validate(fullSize, Format.get("png")));
     }
 
+    @Test
+    void copyReturnsEqualInstance() {
+        OperationList opList = OperationList.builder()
+                .withIdentifier(new Identifier("cats"))
+                .withMetaIdentifier(new MetaIdentifier(new Identifier("cats")))
+                .withPageIndex(2)
+                .withOperations(
+                        new CropByPixels(0, 0, 70, 30),
+                        new Rotate(45),
+                        new Encode(Format.get("jpg")))
+                .withOptions(Map.of("key", "value"))
+                .build();
+
+        OperationList copy = opList.copy();
+
+        assertNotSame(opList, copy);
+        assertEquals(opList, copy);
+        assertEquals(opList.getIdentifier(), copy.getIdentifier());
+        assertEquals(opList.getMetaIdentifier(), copy.getMetaIdentifier());
+        assertEquals(opList.getPageIndex(), copy.getPageIndex());
+        assertEquals(opList.getOptions(), copy.getOptions());
+    }
+
+    @Test
+    void copyDeepCopiesOperations() {
+        OperationList opList = OperationList.builder()
+                .withIdentifier(new Identifier("cats"))
+                .withOperations(new Rotate(45))
+                .build();
+
+        OperationList copy = opList.copy();
+
+        Rotate original = (Rotate) opList.getFirst(Rotate.class);
+        Rotate copied   = (Rotate) copy.getFirst(Rotate.class);
+        assertNotSame(original, copied);
+
+        // Mutating the copy's operation must not affect the original's.
+        copied.addDegrees(90);
+        assertEquals(45, original.getDegrees(), DELTA);
+        assertEquals(135, copied.getDegrees(), DELTA);
+    }
+
+    @Test
+    void copyIsNotFrozen() {
+        OperationList opList = OperationList.builder()
+                .withIdentifier(new Identifier("cats"))
+                .withOperations(new Rotate(45))
+                .build();
+        opList.freeze();
+
+        OperationList copy = opList.copy();
+
+        // Neither the copy nor its operations should be frozen.
+        assertDoesNotThrow(() -> copy.add(new Sharpen(0.5)));
+        assertDoesNotThrow(() ->
+                ((Rotate) copy.getFirst(Rotate.class)).addDegrees(90));
+    }
+
+    /**
+     * Applying mutations to a copy (as the cache-lookup path does) followed by
+     * applying them again to the original must not double-apply in-place
+     * operation mutations such as {@link Rotate#addDegrees}.
+     */
+    @Test
+    void copyPreventsDoubleAppliedMutations() {
+        final Dimension fullSize = new Dimension(2000, 1000);
+        final Info info = Info.builder()
+                .withSize(fullSize)
+                .withMetadata(new Metadata() {
+                    @Override
+                    public Orientation getOrientation() {
+                        return Orientation.ROTATE_90;
+                    }
+                })
+                .build();
+        final OperationList opList = OperationList.builder()
+                .withIdentifier(new Identifier("cats"))
+                .withOperations(
+                        new Rotate(45),
+                        new Encode(Format.get("jpg")))
+                .build();
+
+        DelegateProxy proxy = TestUtil.newDelegateProxy();
+        proxy.getRequestContext().setOperationList(opList, fullSize);
+
+        // Apply mutations to a copy first (mirrors the cache-lookup path)...
+        opList.copy().applyNonEndpointMutations(info, proxy);
+        // ...then to the original.
+        opList.applyNonEndpointMutations(info, proxy);
+
+        Rotate expected = new Rotate(45);
+        expected.addDegrees(Orientation.ROTATE_90.getDegrees());
+        assertEquals(expected, opList.getFirst(Rotate.class));
+    }
+
 }


### PR DESCRIPTION
See #948

OperationList.applyNonEndpointMutations() twice on the same OperationList instance in the cache-miss path (once at line 316 to form the derivative cache key, once at line 405 after the request context is fully populated). Several mutations inside applyNonEndpointMutations append operations via addBefore without checking whether an equivalent operation is already present