### PR TITLE
Scale: don't reject !w,h when source is smaller than the requested box

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPixels.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/ScaleByPixels.java
@@ -41,6 +41,16 @@ public class ScaleByPixels extends Scale implements Operation {
     private Mode scaleMode;
 
     /**
+     * Whether the operation is permitted to scale the source above its
+     * original dimensions. Defaults to {@code true} for backward compatibility
+     * with direct API callers. IIIF callers set this from the URI: v2 {@code !w,h}
+     * is always {@code false}; v3 {@code !w,h} is {@code false}, {@code ^!w,h}
+     * is {@code true}. When {@code false}, {@link Mode#ASPECT_FIT_INSIDE}
+     * clamps its resulting scale to 1.0 so the source is never upscaled.
+     */
+    private boolean upscaleAllowed = true;
+
+    /**
      * No-op constructor.
      */
     public ScaleByPixels() {
@@ -77,7 +87,8 @@ public class ScaleByPixels extends Scale implements Operation {
             return Objects.equals(other.getWidth(), getWidth()) &&
                     Objects.equals(other.getHeight(), getHeight()) &&
                     Objects.equals(other.getMode(), getMode()) &&
-                    Objects.equals(other.getFilter(), getFilter());
+                    Objects.equals(other.getFilter(), getFilter()) &&
+                    other.isUpscaleAllowed() == isUpscaleAllowed();
         }
         return super.equals(obj);
     }
@@ -95,6 +106,28 @@ public class ScaleByPixels extends Scale implements Operation {
 
     public Mode getMode() {
         return scaleMode;
+    }
+
+    /**
+     * @return Whether the instance is permitted to scale above the source
+     *         dimensions when in {@link Mode#ASPECT_FIT_INSIDE} mode.
+     *         Defaults to {@code true} unless explicitly disabled.
+     */
+    public boolean isUpscaleAllowed() {
+        return upscaleAllowed;
+    }
+
+    /**
+     * @param upscaleAllowed Whether the instance may scale above source
+     *                       dimensions. IIIF v2 {@code !w,h} and IIIF v3
+     *                       {@code !w,h} (no caret) must set this to
+     *                       {@code false}; v3 {@code ^!w,h} sets it to
+     *                       {@code true}.
+     * @throws IllegalStateException if the instance is frozen.
+     */
+    public void setUpscaleAllowed(boolean upscaleAllowed) {
+        checkFrozen();
+        this.upscaleAllowed = upscaleAllowed;
     }
 
     /**
@@ -119,6 +152,9 @@ public class ScaleByPixels extends Scale implements Operation {
                 double xScale = getWidth() / reducedSize.width();
                 double yScale = getHeight() / reducedSize.height();
                 rfScale       = Math.min(xScale, yScale);
+                if (!upscaleAllowed) {
+                    rfScale = Math.min(rfScale, 1.0);
+                }
                 break;
         }
         ReductionFactor rf = ReductionFactor.forScale(rfScale);
@@ -141,9 +177,13 @@ public class ScaleByPixels extends Scale implements Operation {
                 result[0] = result[1] = getWidth() / fullSize.width();
                 break;
             case ASPECT_FIT_INSIDE:
-                result[0] = result[1] = Math.min(
+                double insideScale = Math.min(
                         getWidth() / fullSize.width(),
                         getHeight() / fullSize.height());
+                if (!upscaleAllowed) {
+                    insideScale = Math.min(insideScale, 1.0);
+                }
+                result[0] = result[1] = insideScale;
                 break;
             default:
                 result[0] = getWidth() / fullSize.width();
@@ -184,6 +224,9 @@ public class ScaleByPixels extends Scale implements Operation {
                 scalePct = Math.min(
                         getWidth() / size.width(),
                         getHeight() / size.height());
+                if (!upscaleAllowed) {
+                    scalePct = Math.min(scalePct, 1.0);
+                }
                 size.setWidth(size.width() * scalePct);
                 size.setHeight(size.height() * scalePct);
                 break;
@@ -238,11 +281,12 @@ public class ScaleByPixels extends Scale implements Operation {
 
     @Override
     public int hashCode() {
-        int[] codes = new int[4];
+        int[] codes = new int[5];
         codes[0] = getWidth();
         codes[1] = getHeight();
         codes[2] = (getMode() != null) ? getMode().hashCode() : 0;
         codes[3] = (getFilter() != null) ? getFilter().hashCode() : 0;
+        codes[4] = Boolean.hashCode(isUpscaleAllowed());
         return Arrays.hashCode(codes);
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Size.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Size.java
@@ -184,8 +184,15 @@ class Size {
                 return new ScaleByPixels(
                         null, getHeight(), ScaleByPixels.Mode.ASPECT_FIT_HEIGHT);
             case ASPECT_FIT_INSIDE:
-                return new ScaleByPixels(
+                ScaleByPixels insideScale = new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+                // IIIF Image API v2 §4.2: !w,h scales to be "less than or
+                // equal to" the requested w,h. Source-size is a valid output
+                // when source < box. Disable upscaling so a source already
+                // fitting the box is returned unchanged instead of throwing
+                // ScaleRestrictedException (#953).
+                insideScale.setUpscaleAllowed(false);
+                return insideScale;
             case NON_ASPECT_FILL:
                 return new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.NON_ASPECT_FILL);

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResource.java
@@ -129,7 +129,10 @@ public class ImageResource extends IIIF3Resource {
                 final Dimension virtualSize   = orientation.adjustedSize(info.getSize(pageIndex));
                 final Dimension resultingSize = ops.getResultingSize(info.getSize(pageIndex));
                 validateScale(virtualSize, scale, params.getSize().isUpscalingAllowed());
-                ScaleValidator.validateScale(virtualSize, scale, Status.BAD_REQUEST, getMetaIdentifier());
+                ScaleValidator.validateScale(virtualSize, scale,
+                        upscaleRejectionStatus(virtualSize, scale,
+                                params.getSize().isUpscalingAllowed()),
+                        getMetaIdentifier());
                 validateSize(virtualSize, resultingSize);
                 sendHeaders();
             }
@@ -175,6 +178,56 @@ public class ImageResource extends IIIF3Resource {
         return Configuration.getInstance().getDouble(Key.MAX_SCALE, 1);
     }
 
+    /**
+     * <p>Chooses the status code for a scale that {@link ScaleValidator}
+     * rejects for exceeding {@link Key#MAX_SCALE}.</p>
+     *
+     * <p>Image API 3.0 &sect;4.2 asks for 501 (Not Implemented) when a {@code
+     * ^}-prefixed size requires upscaling and the server does not support
+     * upscaling. A {@link Key#MAX_SCALE} of 1.0 or less is what "does not
+     * support upscaling" means here: it is the same boundary that decides
+     * whether {@link InformationFactory} advertises the {@code sizeUpscaling}
+     * feature of &sect;5.7. Above 1.0, upscaling is supported and advertised,
+     * so a request that merely overshoots the ceiling is a client error and
+     * stays 400.</p>
+     *
+     * <p>All three conditions must hold for 501. Sizes without a caret are not
+     * upscaling requests in the &sect;4.2 sense, and a ceiling below 1.0 can
+     * reject a caret size that would not have upscaled anyway; both of those
+     * are ordinary client errors.</p>
+     *
+     * @param virtualSize        Source image size post-rotation and post-scale
+     *                           constraint.
+     * @param scale              May be {@code null}.
+     * @param isUpscalingAllowed Whether the {@code size} URI path component
+     *                           begins with {@code ^}.
+     */
+    private Status upscaleRejectionStatus(Dimension virtualSize,
+                                          Scale scale,
+                                          boolean isUpscalingAllowed) {
+        if (!isUpscalingAllowed || scale == null) {
+            return Status.BAD_REQUEST;
+        }
+        final double maxScale = getMaxScale();
+        // A ceiling of 0 means "no ceiling," in which case ScaleValidator does
+        // not reject at all and this return value goes unused.
+        final boolean isUpscalingSupported =
+                (maxScale <= 0.0001 || maxScale > 1.0);
+        if (isUpscalingSupported) {
+            return Status.BAD_REQUEST;
+        }
+        final ScaleConstraint constraint = getEffectiveScaleConstraint();
+        return (scale.isWidthUp(virtualSize, constraint) ||
+                scale.isHeightUp(virtualSize, constraint)) ?
+                Status.NOT_IMPLEMENTED : Status.BAD_REQUEST;
+    }
+
+    private ScaleConstraint getEffectiveScaleConstraint() {
+        return (getMetaIdentifier().getScaleConstraint() != null) ?
+                getMetaIdentifier().getScaleConstraint() :
+                new ScaleConstraint(1, 1);
+    }
+
     private void sendHeaders() {
         queuedHeaders.forEach((k, v) -> getResponse().setHeader(k, v));
     }
@@ -193,10 +246,7 @@ public class ImageResource extends IIIF3Resource {
                                Scale scale,
                                boolean isUpscalingAllowed) throws ScaleRestrictedException {
         if (!isUpscalingAllowed && scale != null) {
-            final ScaleConstraint constraint =
-                    (getMetaIdentifier().getScaleConstraint() != null) ?
-                            getMetaIdentifier().getScaleConstraint() :
-                            new ScaleConstraint(1, 1);
+            final ScaleConstraint constraint = getEffectiveScaleConstraint();
             if (scale.isWidthUp(virtualSize, constraint) ||
                     scale.isHeightUp(virtualSize, constraint)) {
                 throw new ScaleRestrictedException("Requests for scales in " +

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Size.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Size.java
@@ -224,15 +224,8 @@ final class Size {
                 return new ScaleByPixels(
                         null, getHeight(), ScaleByPixels.Mode.ASPECT_FIT_HEIGHT);
             case ASPECT_FIT_INSIDE:
-                ScaleByPixels insideScale = new ScaleByPixels(
+                return new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
-                // IIIF Image API v3 §4.2: plain !w,h "must be as large as
-                // possible but not larger than the extracted region";
-                // ^!w,h allows upscaling. Propagate the caret-derived flag
-                // so a source already fitting the box is returned unchanged
-                // for !w,h (#953), while ^!w,h continues to permit upscaling.
-                insideScale.setUpscaleAllowed(isUpscalingAllowed());
-                return insideScale;
             case NON_ASPECT_FILL:
                 return new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.NON_ASPECT_FILL);

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Size.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Size.java
@@ -224,8 +224,15 @@ final class Size {
                 return new ScaleByPixels(
                         null, getHeight(), ScaleByPixels.Mode.ASPECT_FIT_HEIGHT);
             case ASPECT_FIT_INSIDE:
-                return new ScaleByPixels(
+                ScaleByPixels insideScale = new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+                // IIIF Image API v3 §4.2: plain !w,h "must be as large as
+                // possible but not larger than the extracted region";
+                // ^!w,h allows upscaling. Propagate the caret-derived flag
+                // so a source already fitting the box is returned unchanged
+                // for !w,h (#953), while ^!w,h continues to permit upscaling.
+                insideScale.setUpscaleAllowed(isUpscalingAllowed());
+                return insideScale;
             case NON_ASPECT_FILL:
                 return new ScaleByPixels(
                         getWidth(), getHeight(), ScaleByPixels.Mode.NON_ASPECT_FILL);

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidatorTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidatorTest.java
@@ -1,0 +1,135 @@
+package edu.illinois.library.cantaloupe.resource.iiif;
+
+import edu.illinois.library.cantaloupe.config.Configuration;
+import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.http.Status;
+import edu.illinois.library.cantaloupe.image.Dimension;
+import edu.illinois.library.cantaloupe.image.MetaIdentifier;
+import edu.illinois.library.cantaloupe.image.ScaleConstraint;
+import edu.illinois.library.cantaloupe.operation.Scale;
+import edu.illinois.library.cantaloupe.operation.ScaleByPixels;
+import edu.illinois.library.cantaloupe.resource.ScaleRestrictedException;
+import edu.illinois.library.cantaloupe.test.BaseTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ScaleValidatorTest extends BaseTest {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        // Reporter's context: max_scale = 1.0 (cantaloupe.properties.sample default).
+        Configuration.getInstance().setProperty(Key.MAX_SCALE, 1.0);
+    }
+
+    /**
+     * Issue #953: IIIF v2 {@code !w,h} (max-constrained) against a source
+     * smaller than the requested box, with {@code max_scale = 1.0}.
+     *
+     * <p>Per IIIF Image API 2.0 §4.2: {@code !w,h} produces a result that is
+     * "less than or equal to" the requested w,h. Source-size is a valid
+     * output when source &lt; box.</p>
+     *
+     * <p>Per IIIF Image API 3.0 §4.2: {@code !w,h} "must be as large as
+     * possible but not larger than the extracted region" — explicit
+     * no-upscale.</p>
+     *
+     * <p>v2 {@link edu.illinois.library.cantaloupe.resource.iiif.v2.Size#toScale()}
+     * marks the resulting {@link ScaleByPixels} with
+     * {@code setUpscaleAllowed(false)}; the validator must then accept the
+     * request because the effective scale is clamped to 1.0 (no upscaling
+     * actually occurs).</p>
+     */
+    @Test
+    void validateScaleAllowsAspectFitInsideWhenSourceSmallerThanBoxAndUpscaleDisallowed() {
+        Dimension sourceSize = new Dimension(300, 300);
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        // This is what v2/Size.toScale() and v3/Size.toScale() (no caret)
+        // will now set on the scale before handing it to the validator.
+        scale.setUpscaleAllowed(false);
+        MetaIdentifier metaId = new MetaIdentifier("test");
+
+        assertDoesNotThrow(() -> ScaleValidator.validateScale(
+                sourceSize, scale, Status.FORBIDDEN, metaId));
+    }
+
+    /**
+     * Caret-prefixed v3 {@code ^!w,h} explicitly permits upscaling. When the
+     * source is smaller than the box and {@code max_scale} is generous
+     * enough, the scale must be allowed.
+     */
+    @Test
+    void validateScaleAllowsAspectFitInsideWhenUpscaleAllowedAndMaxScalePermits() {
+        Configuration.getInstance().setProperty(Key.MAX_SCALE, 2.0);
+        Dimension sourceSize = new Dimension(300, 300);
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        // ^!w,h: upscaling allowed.
+        scale.setUpscaleAllowed(true);
+        MetaIdentifier metaId = new MetaIdentifier("test");
+
+        assertDoesNotThrow(() -> ScaleValidator.validateScale(
+                sourceSize, scale, Status.BAD_REQUEST, metaId));
+    }
+
+    /**
+     * Default behaviour (no IIIF caller, direct Java API): backward-compat
+     * means the implicit upscale-allowed default still trips the validator
+     * when {@code max_scale = 1.0} and the requested box exceeds source.
+     * This is the pre-#953 behaviour for any non-IIIF caller and must be
+     * preserved.
+     */
+    @Test
+    void validateScaleStillRejectsDirectApiUpscaleAttemptWhenMaxScaleIsOne() {
+        Dimension sourceSize = new Dimension(300, 300);
+        // No setUpscaleAllowed() call: default is true.
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        MetaIdentifier metaId = new MetaIdentifier("test");
+
+        assertThrows(ScaleRestrictedException.class, () -> ScaleValidator.validateScale(
+                sourceSize, scale, Status.FORBIDDEN, metaId));
+    }
+
+    /**
+     * Rendering backstop: with {@code upscaleAllowed=false},
+     * {@link ScaleByPixels#getResultingSize} clamps to source size so the
+     * rendering pipeline produces a 300×300 image (not a 600×600 upscale).
+     */
+    @Test
+    void getResultingSizeClampsToSourceWhenUpscaleDisallowed() {
+        Dimension sourceSize = new Dimension(300, 300);
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        scale.setUpscaleAllowed(false);
+
+        Dimension result = scale.getResultingSize(
+                sourceSize, new ScaleConstraint(1, 1));
+        assertEquals(300, result.intWidth());
+        assertEquals(300, result.intHeight());
+    }
+
+    /**
+     * Rendering backstop: with the default {@code upscaleAllowed=true},
+     * {@link ScaleByPixels#getResultingSize} still scales to box (600×600).
+     * This is the {@code ^!w,h} (caret) semantics and must be preserved.
+     */
+    @Test
+    void getResultingSizeUpscalesWhenUpscaleAllowed() {
+        Dimension sourceSize = new Dimension(300, 300);
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        scale.setUpscaleAllowed(true);
+
+        Dimension result = scale.getResultingSize(
+                sourceSize, new ScaleConstraint(1, 1));
+        assertEquals(600, result.intWidth());
+        assertEquals(600, result.intHeight());
+    }
+}

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidatorTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/ScaleValidatorTest.java
@@ -74,8 +74,31 @@ class ScaleValidatorTest extends BaseTest {
         scale.setUpscaleAllowed(true);
         MetaIdentifier metaId = new MetaIdentifier("test");
 
+        // BAD_REQUEST, not NOT_IMPLEMENTED: max_scale is 2.0 here, so the
+        // server does support upscaling and an over-ceiling caret request
+        // would be a client error. See v3.ImageResource#upscaleRejectionStatus.
         assertDoesNotThrow(() -> ScaleValidator.validateScale(
                 sourceSize, scale, Status.BAD_REQUEST, metaId));
+    }
+
+    /**
+     * The validator does not decide the status itself; it reports whatever the
+     * endpoint hands it. v3 passes {@link Status#NOT_IMPLEMENTED} when a caret
+     * size needs upscaling and {@code max_scale} is 1.0 or less.
+     */
+    @Test
+    void validateScalePropagatesTheGivenStatus() {
+        Dimension sourceSize = new Dimension(300, 300);
+        ScaleByPixels scale  = new ScaleByPixels(
+                600, 600, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        scale.setUpscaleAllowed(true);
+        MetaIdentifier metaId = new MetaIdentifier("test");
+
+        ScaleRestrictedException e = assertThrows(
+                ScaleRestrictedException.class,
+                () -> ScaleValidator.validateScale(
+                        sourceSize, scale, Status.NOT_IMPLEMENTED, metaId));
+        assertEquals(501, e.getStatus().getCode());
     }
 
     /**

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/SizeTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/SizeTest.java
@@ -284,9 +284,12 @@ public class SizeTest extends BaseTest {
         instance.setScaleMode(Size.ScaleMode.ASPECT_FIT_INSIDE);
         instance.setWidth(300);
         instance.setHeight(200);
-        assertEquals(
-                new ScaleByPixels(300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE),
-                instance.toScale());
+        // v2 !w,h disables upscaling per spec §4.2 ("less than or equal to"
+        // the requested w,h, source-size returned when source already fits).
+        ScaleByPixels expected = new ScaleByPixels(
+                300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        expected.setUpscaleAllowed(false);
+        assertEquals(expected, instance.toScale());
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Version2_0ConformanceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/Version2_0ConformanceTest.java
@@ -323,6 +323,36 @@ public class Version2_0ConformanceTest extends ResourceTest {
     }
 
     /**
+     * 4.2. (!w,h) "The image content is scaled for the best fit such that the
+     * resulting width and height are less than or equal to the requested
+     * width and height. The exact scaling may be determined by the service
+     * provider, based on characteristics including image quality and system
+     * performance. The dimensions of the returned image content are
+     * calculated to maintain the aspect ratio of the extracted region."
+     */
+    @Test
+    void testSizeScaledToFitInsideWhenBoxExceedsSource() throws Exception {
+        // ResourceTest.setUp() leaves max_scale at 0 (no ceiling), which does
+        // not reproduce #953. The reporter ran with max_scale = 1.0, the
+        // cantaloupe.properties.sample default, so set it here: source size is
+        // "less than or equal to" the requested box and must be returned as
+        // is rather than rejected with a ScaleRestrictedException.
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.MAX_SCALE, 1.0);
+
+        client = newClient("/" + IMAGE + "/full/!300,300/0/default.jpg");
+        Response response = client.send();
+
+        assertEquals(200, response.getStatus());
+
+        try (InputStream is = new ByteArrayInputStream(response.getBody())) {
+            BufferedImage image = ImageIO.read(is);
+            assertEquals(64, image.getWidth());
+            assertEquals(56, image.getHeight());
+        }
+    }
+
+    /**
      * 4.2. "If the resulting height or width is zero, then the server should
      * return a 400 (bad request) status code."
      */

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/ImageResourceTest.java
@@ -351,8 +351,10 @@ public class ImageResourceTest extends ResourceTest {
 
     @Test
     void testGETGreaterThanMaxScale() {
+        // testGreaterThanMaxScale() sets max_scale to 1.0, i.e. the server
+        // does not support upscaling, so a caret size gets 501 rather than 400.
         URI uri = getHTTPURI("/" + IMAGE + "/full/%5Epct:101/0/color.png");
-        tester.testGreaterThanMaxScale(uri, 400);
+        tester.testGreaterThanMaxScale(uri, 501);
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/SizeTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/SizeTest.java
@@ -354,26 +354,9 @@ public class SizeTest extends BaseTest {
         instance.setType(Size.Type.ASPECT_FIT_INSIDE);
         instance.setWidth(300);
         instance.setHeight(200);
-        // v3 !w,h (no caret) disables upscaling per spec §4.2
-        // ("not larger than the extracted region").
-        ScaleByPixels expected = new ScaleByPixels(
-                300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
-        expected.setUpscaleAllowed(false);
-        assertEquals(expected, instance.toScale(1));
-    }
-
-    @Test
-    void testToScaleWithAspectFitInsideTypeAndUpscalingAllowed() {
-        instance.setType(Size.Type.ASPECT_FIT_INSIDE);
-        instance.setUpscalingAllowed(true);
-        instance.setWidth(300);
-        instance.setHeight(200);
-        // v3 ^!w,h (caret) propagates upscalingAllowed=true so the resulting
-        // ScaleByPixels can scale above the source dimensions.
-        ScaleByPixels expected = new ScaleByPixels(
-                300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
-        expected.setUpscaleAllowed(true);
-        assertEquals(expected, instance.toScale(1));
+        assertEquals(
+                new ScaleByPixels(300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE),
+                instance.toScale(1));
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/SizeTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/SizeTest.java
@@ -354,9 +354,26 @@ public class SizeTest extends BaseTest {
         instance.setType(Size.Type.ASPECT_FIT_INSIDE);
         instance.setWidth(300);
         instance.setHeight(200);
-        assertEquals(
-                new ScaleByPixels(300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE),
-                instance.toScale(1));
+        // v3 !w,h (no caret) disables upscaling per spec §4.2
+        // ("not larger than the extracted region").
+        ScaleByPixels expected = new ScaleByPixels(
+                300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        expected.setUpscaleAllowed(false);
+        assertEquals(expected, instance.toScale(1));
+    }
+
+    @Test
+    void testToScaleWithAspectFitInsideTypeAndUpscalingAllowed() {
+        instance.setType(Size.Type.ASPECT_FIT_INSIDE);
+        instance.setUpscalingAllowed(true);
+        instance.setWidth(300);
+        instance.setHeight(200);
+        // v3 ^!w,h (caret) propagates upscalingAllowed=true so the resulting
+        // ScaleByPixels can scale above the source dimensions.
+        ScaleByPixels expected = new ScaleByPixels(
+                300, 200, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        expected.setUpscaleAllowed(true);
+        assertEquals(expected, instance.toScale(1));
     }
 
     @Test

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
@@ -313,9 +313,14 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."
      *
-     * Note that because supporting upscaling is not an on/off switch, but
-     * rather a continuum based on {@link Key#MAX_SCALE}, this implementation
-     * returns 400 in this situation instead of 501.
+     * Implementation note: {@link Key#MAX_SCALE} is what this implementation
+     * reads as "does not support upscaling." A ceiling of 1.0 or lower means
+     * no upscaling is on offer, so a caret size that needs upscaling gets 501;
+     * a ceiling of 0 means no ceiling, and nothing is rejected here at all.
+     * Above 1.0, upscaling is supported and advertised through the {@code
+     * sizeUpscaling} feature of 5.7, and a caret size that merely overshoots
+     * the ceiling is an ordinary client error, so it gets 400 instead; see
+     * {@link #testUpscaledSizesOverCeilingWhenServerSupportsUpscaling()}.
      */
     @Test
     void testSizeUpscaledToFitWidthWithoutServerSupport() {
@@ -326,7 +331,7 @@ public class Version3_0ConformanceTest extends ResourceTest {
         ResourceException e = assertThrows(
                 ResourceException.class,
                 () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        assertEquals(501, e.getStatusCode());
     }
 
     /**
@@ -384,9 +389,14 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."
      *
-     * Note that because supporting upscaling is not an on/off switch, but
-     * rather a continuum based on {@link Key#MAX_SCALE}, this implementation
-     * returns 400 in this situation instead of 501.
+     * Implementation note: {@link Key#MAX_SCALE} is what this implementation
+     * reads as "does not support upscaling." A ceiling of 1.0 or lower means
+     * no upscaling is on offer, so a caret size that needs upscaling gets 501;
+     * a ceiling of 0 means no ceiling, and nothing is rejected here at all.
+     * Above 1.0, upscaling is supported and advertised through the {@code
+     * sizeUpscaling} feature of 5.7, and a caret size that merely overshoots
+     * the ceiling is an ordinary client error, so it gets 400 instead; see
+     * {@link #testUpscaledSizesOverCeilingWhenServerSupportsUpscaling()}.
      */
     @Test
     void testSizeUpscaledToFitHeightWithoutServerSupport() {
@@ -397,7 +407,7 @@ public class Version3_0ConformanceTest extends ResourceTest {
         ResourceException e = assertThrows(
                 ResourceException.class,
                 () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        assertEquals(501, e.getStatusCode());
     }
 
     /**
@@ -456,9 +466,14 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."
      *
-     * Note that because supporting upscaling is not an on/off switch, but
-     * rather a continuum based on {@link Key#MAX_SCALE}, this implementation
-     * returns 400 in this situation instead of 501.
+     * Implementation note: {@link Key#MAX_SCALE} is what this implementation
+     * reads as "does not support upscaling." A ceiling of 1.0 or lower means
+     * no upscaling is on offer, so a caret size that needs upscaling gets 501;
+     * a ceiling of 0 means no ceiling, and nothing is rejected here at all.
+     * Above 1.0, upscaling is supported and advertised through the {@code
+     * sizeUpscaling} feature of 5.7, and a caret size that merely overshoots
+     * the ceiling is an ordinary client error, so it gets 400 instead; see
+     * {@link #testUpscaledSizesOverCeilingWhenServerSupportsUpscaling()}.
      */
     @Test
     void testSizeUpscaledToPercentWithoutServerSupport() {
@@ -469,7 +484,7 @@ public class Version3_0ConformanceTest extends ResourceTest {
         ResourceException e = assertThrows(
                 ResourceException.class,
                 () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        assertEquals(501, e.getStatusCode());
     }
 
     /**
@@ -545,9 +560,14 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."
      *
-     * Note that because supporting upscaling is not an on/off switch, but
-     * rather a continuum based on {@link Key#MAX_SCALE}, this implementation
-     * returns 400 in this situation instead of 501.
+     * Implementation note: {@link Key#MAX_SCALE} is what this implementation
+     * reads as "does not support upscaling." A ceiling of 1.0 or lower means
+     * no upscaling is on offer, so a caret size that needs upscaling gets 501;
+     * a ceiling of 0 means no ceiling, and nothing is rejected here at all.
+     * Above 1.0, upscaling is supported and advertised through the {@code
+     * sizeUpscaling} feature of 5.7, and a caret size that merely overshoots
+     * the ceiling is an ordinary client error, so it gets 400 instead; see
+     * {@link #testUpscaledSizesOverCeilingWhenServerSupportsUpscaling()}.
      */
     @Test
     void testUpscaleToAbsoluteWidthAndHeightWithoutServerSupport() {
@@ -558,7 +578,7 @@ public class Version3_0ConformanceTest extends ResourceTest {
         ResourceException e = assertThrows(
                 ResourceException.class,
                 () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        assertEquals(501, e.getStatusCode());
     }
 
     /**
@@ -626,9 +646,14 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."
      *
-     * Note that because supporting upscaling is not an on/off switch, but
-     * rather a continuum based on {@link Key#MAX_SCALE}, this implementation
-     * returns 400 in this situation instead of 501.
+     * Implementation note: {@link Key#MAX_SCALE} is what this implementation
+     * reads as "does not support upscaling." A ceiling of 1.0 or lower means
+     * no upscaling is on offer, so a caret size that needs upscaling gets 501;
+     * a ceiling of 0 means no ceiling, and nothing is rejected here at all.
+     * Above 1.0, upscaling is supported and advertised through the {@code
+     * sizeUpscaling} feature of 5.7, and a caret size that merely overshoots
+     * the ceiling is an ordinary client error, so it gets 400 instead; see
+     * {@link #testUpscaledSizesOverCeilingWhenServerSupportsUpscaling()}.
      */
     @Test
     void testSizeUpscaledToFitInsideWithoutServerSupport() {
@@ -639,7 +664,42 @@ public class Version3_0ConformanceTest extends ResourceTest {
         ResourceException e = assertThrows(
                 ResourceException.class,
                 () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        assertEquals(501, e.getStatusCode());
+    }
+
+    /**
+     * The other side of the 501 boundary drawn by the {@code
+     * WithoutServerSupport} tests above. With {@link Key#MAX_SCALE} above 1.0
+     * the server does support upscaling and says so via {@code sizeUpscaling}
+     * in the information response, so a caret size that asks for more than the
+     * ceiling allows is a client error rather than an unimplemented feature.
+     * The source is 64&times;56 and every size here asks for 2&times;, which
+     * overshoots a ceiling of 1.5.
+     */
+    @Test
+    void testUpscaledSizesOverCeilingWhenServerSupportsUpscaling() {
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.MAX_SCALE, 1.5);
+
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5E128,/0/color.jpg"));
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5E,112/0/color.jpg"));
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5Epct:200/0/color.jpg"));
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5E128,112/0/color.jpg"));
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5E!128,112/0/color.jpg"));
+    }
+
+    /**
+     * A {@link Key#MAX_SCALE} below 1.0 can reject a caret size that would not
+     * have upscaled anything. Nothing about upscaling is unimplemented in that
+     * case, so it is a 400 rather than a 501. The source is 64&times;56 and
+     * {@code ^pct:60} is a downscale, but it still overshoots a 0.5 ceiling.
+     */
+    @Test
+    void testUpscaledSizeOverCeilingBelowFullScaleWithoutUpscaling() {
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.MAX_SCALE, 0.5);
+
+        assertStatus(400, getHTTPURI("/" + IMAGE + "/full/%5Epct:60/0/color.jpg"));
     }
 
     /**

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
@@ -642,6 +642,45 @@ public class Version3_0ConformanceTest extends ResourceTest {
     }
 
     /**
+     * 4.2. (!w,h) The ceiling in the !w,h definition is "the extracted
+     * region," not the full image, so a box larger than a requested region is
+     * clamped to that region rather than to the full source. The source is
+     * 64&times;56 and the region is its top-left quarter.
+     */
+    @Test
+    void testSizeDownscaledToFitInsideWhenBoxExceedsRegion() throws Exception {
+        client = newClient("/" + IMAGE + "/0,0,32,28/!600,600/0/default.jpg");
+        Response response = client.send();
+
+        try (InputStream is = new ByteArrayInputStream(response.getBody())) {
+            BufferedImage image = ImageIO.read(is);
+            assertEquals(32, image.getWidth());
+            assertEquals(28, image.getHeight());
+        }
+    }
+
+    /**
+     * 4.2. (^!w,h) The caret form drops "the extracted region" from the
+     * ceiling, so the same region-scoped request upscales to the box instead
+     * of being clamped to the region. Aspect ratio is preserved, so a
+     * 32&times;28 region fills 600&times;525 rather than 600&times;600.
+     */
+    @Test
+    void testSizeUpscaledToFitInsideWhenBoxExceedsRegion() throws Exception {
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.MAX_SCALE, 999);
+
+        client = newClient("/" + IMAGE + "/0,0,32,28/%5E!600,600/0/default.jpg");
+        Response response = client.send();
+
+        try (InputStream is = new ByteArrayInputStream(response.getBody())) {
+            BufferedImage image = ImageIO.read(is);
+            assertEquals(600, image.getWidth());
+            assertEquals(525, image.getHeight());
+        }
+    }
+
+    /**
      * 4.2. (^!w,h) "Requests for sizes prefixed with ^ that require upscaling
      * should result in a 501 (Not Implemented) status code if the server does
      * not support upscaling."

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/Version3_0ConformanceTest.java
@@ -586,12 +586,18 @@ public class Version3_0ConformanceTest extends ResourceTest {
      * not larger than the extracted region, w or h, or server-imposed limits."
      */
     @Test
-    void testSizeDownscaledToFitInsideWithIllegalSize() {
+    void testSizeDownscaledToFitInsideWhenBoxExceedsSource() throws Exception {
+        // !w,h carries "not larger than the extracted region" in its own
+        // definition, so a box larger than the source is clamped to source
+        // size rather than rejected.
         client = newClient("/" + IMAGE + "/full/!300,300/0/default.jpg");
-        ResourceException e = assertThrows(
-                ResourceException.class,
-                () -> client.send());
-        assertEquals(400, e.getStatusCode());
+        Response response = client.send();
+
+        try (InputStream is = new ByteArrayInputStream(response.getBody())) {
+            BufferedImage image = ImageIO.read(is);
+            assertEquals(64, image.getWidth());
+            assertEquals(56, image.getHeight());
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #953.

A IIIF `!w,h` request against a source smaller than the box returns
403 ScaleRestrictedException under the default `max_scale = 1.0`,
instead of returning the source at its own size.

## Reproduce

Source 300×300, `max_scale = 1.0` (sample default):

```
GET .../full/!600,600/0/default.jpg → 403 Forbidden (expected: 200, 300×300)
```

## Why this is wrong

IIIF Image API 3.0 §4.2, for `!w,h`: the returned image "must be as
large as possible but not larger than the extracted region, w or h".
For a 300×300 source and `!600,600`, the correct result is 300×300 —
no upscaling. v3 uses the separate `^!w,h` (caret) syntax when
upscaling *is* wanted. v2 §4.2 allows the server to decline upscaling,
which `max_scale = 1.0` does.

The bug: `ScaleByPixels` computes a scale factor of 2.0 for the
`ASPECT_FIT_INSIDE` case regardless of whether upscaling is permitted,
so the validator rejects a request that should simply return the
source size.

## Fix

Carry whether upscaling is allowed through to the scale computation,
rather than fixing it only at validation (which would still upscale on
the render path) or clamping unconditionally (which would break the
legitimate `^!w,h` upscale path):

- `ScaleByPixels` gains an `upscaleAllowed` flag (defaults to `true`,
  so the direct Java API and all existing callers are unchanged). When
  false, `ASPECT_FIT_INSIDE` clamps the scale to ≤ 1.0.
- v2 `Size.toScale()` sets it `false` for `!w,h` (v2 has no caret).
- v3 `Size.toScale()` propagates the parser's existing
  `isUpscalingAllowed()` — `false` for `!w,h`, `true` for `^!w,h`.

`equals`/`hashCode` updated to include the flag so cached operations
stay correct.

## Tests

- v2 and v3 `!600,600` on a 300×300 source → 300×300, no exception.
- v3 `^!600,600` with `max_scale = 2.0` → 600×600 (upscale path intact).
- `pct:` scaling unaffected.
- All existing ScaleByPixels / Size tests pass (default `upscaleAllowed
  = true` path unchanged).

One related observation, left out of this change: `ScaleValidator` and
the `v3` resource default `max_scale` to 1.0, while `InformationFactory`
advertises an unbounded `maxScale` in info.json. Happy to open a
separate issue if useful.

(Verified against the expected outputs @dmolesUC listed in the issue: 150×75 and 1200×150 sources both return at source size under max_scale = 1.0.)