### PR TITLE
Fix ArrayIndexOutOfBoundsException scaling grayscale+alpha images

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/resample/ResampleOp.java
@@ -221,8 +221,15 @@ public class ResampleOp extends AdvancedResizeOp {
                     " but must be at least 3x3.");
         }
 
+        // This resampler only supports 1- (gray), 3- (RGB), and 4-channel
+        // (ARGB) images. Two-channel gray+alpha images (e.g. PNG color type 4)
+        // and palette/binary images would otherwise cause the horizontal and
+        // vertical sampling loops to read three or four channels out of a
+        // narrower row, throwing ArrayIndexOutOfBoundsException. Convert them
+        // up front to a supported layout, preserving alpha when present.
         if (srcImage.getType() == BufferedImage.TYPE_BYTE_BINARY ||
-                srcImage.getType() == BufferedImage.TYPE_BYTE_INDEXED) {
+                srcImage.getType() == BufferedImage.TYPE_BYTE_INDEXED ||
+                srcImage.getSampleModel().getNumBands() == 2) {
             srcImage = ImageUtils.convert(srcImage, srcImage.getColorModel().hasAlpha() ?
                     BufferedImage.TYPE_4BYTE_ABGR : BufferedImage.TYPE_3BYTE_BGR);
         }

--- a/src/test/java/edu/illinois/library/cantaloupe/processor/Java2DUtilTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/processor/Java2DUtilTest.java
@@ -816,6 +816,23 @@ class Java2DUtilTest extends BaseTest {
         assertEquals(1, outImage.getHeight());
     }
 
+    @Test
+    void scaleWithGrayAlphaImage() {
+        // Grayscale+alpha images (e.g. PNG color type 4) have two channels,
+        // which the resampler doesn't handle natively; without an up-front
+        // conversion this throws ArrayIndexOutOfBoundsException.
+        BufferedImage inImage = newGrayImage(100, 100, 8, true);
+
+        ScaleByPixels scale = new ScaleByPixels(
+                50, 50, ScaleByPixels.Mode.ASPECT_FIT_INSIDE);
+        ScaleConstraint sc = new ScaleConstraint(1, 1);
+        ReductionFactor rf = new ReductionFactor(1);
+
+        BufferedImage outImage = Java2DUtil.scale(inImage, scale, sc, rf, false);
+        assertEquals(50, outImage.getWidth());
+        assertEquals(50, outImage.getHeight());
+    }
+
     /* sharpen() */
 
     @Test


### PR DESCRIPTION
## Problem

Applying a **scaled grayscale+alpha PNG** overlay (PNG color type 4) throws `ArrayIndexOutOfBoundsException` in the Java2D overlay compositor, returning a 500.

The failure is not in *reading* the PNG — ImageIO decodes it fine into a 2-band `TYPE_CUSTOM` image. It's in the **scaling** step: `Java2DUtil.scale()` runs the overlay through the custom `ResampleOp` resampler, which only handles 1-, 3-, and 4-channel images. For a 2-channel image the sampling loops still read three samples per pixel out of a `srcWidth * 2` row, running off the end:

```
ArrayIndexOutOfBoundsException: Index 200 out of bounds for length 200
    at ResampleOp.horizontalFromSrcToWork(ResampleOp.java:419)
    at ResampleOp.doFilter(ResampleOp.java:259)
```

## Fix

Extend the existing up-front normalization in `ResampleOp.doFilter` — which already converts binary/indexed images — to also convert 2-band (gray+alpha) images to `TYPE_4BYTE_ABGR`, preserving alpha. This fixes it at the root, covering both scaled overlays and gray+alpha source images that get scaled.

## Testing

- Added regression test `Java2DUtilTest.scaleWithGrayAlphaImage`.
- Verified against the real `ResampleOp` source: reproduces the AIOOBE before the change; scales cleanly to `TYPE_4BYTE_ABGR` after.
