### PR TITLE
Extract a IIIFRequest object from Request

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/image/Identifier.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/Identifier.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  *
  * <p>The input steps must be reversed for output. Note that requests can
  * supply a {@link
- * edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER}
+ * edu.illinois.library.cantaloupe.resource.IIIFRequest#PUBLIC_IDENTIFIER_HEADER}
  * to suggest that the identifier supplied in a URI is different from the one
  * the user agent is seeing and supplying to a reverse proxy.</p>
  *
@@ -48,7 +48,7 @@ import java.io.IOException;
  *
  * <ol>
  *     <li>Replace the URI identifier with the one from {@link
- *     edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER},
+ *     edu.illinois.library.cantaloupe.resource.IIIFRequest#PUBLIC_IDENTIFIER_HEADER},
  *     if present</li>
  *     <li>Encode slashes</li>
  *     <li>URI encoding</li>

--- a/src/main/java/edu/illinois/library/cantaloupe/image/MetaIdentifier.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/image/MetaIdentifier.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  *
  * <p>The input steps must be reversed for output. Note that requests can
  * supply a {@link
- * edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER}
+ * edu.illinois.library.cantaloupe.resource.IIIFRequest#PUBLIC_IDENTIFIER_HEADER}
  * to suggest that the meta-identifier supplied in a URI is different from the
  * one the user agent is seeing and supplying to a reverse proxy.</p>
  *
@@ -48,7 +48,7 @@ import java.util.Objects;
  *
  * <ol>
  *     <li>Replace the URI meta-identifier with the one from {@link
- *     edu.illinois.library.cantaloupe.resource.Request#PUBLIC_IDENTIFIER_HEADER},
+ *     edu.illinois.library.cantaloupe.resource.IIIFRequest#PUBLIC_IDENTIFIER_HEADER},
  *     if present</li>
  *     <li>Encode slashes</li>
  *     <li>URI encoding</li>

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/AbstractResource.java
@@ -229,7 +229,7 @@ public abstract class AbstractResource {
      */
     protected MetaIdentifier getMetaIdentifier() {
         if (metaIdentifier == null) {
-            String pathComponent = getRequest().getIdentifierPathComponent();
+            String pathComponent = ((IIIFRequest) getRequest()).getIdentifierPathComponent();
             if (pathComponent != null) {
                 metaIdentifier = MetaIdentifier.fromURIPathComponent(
                         pathComponent, getDelegateProxy());
@@ -279,7 +279,7 @@ public abstract class AbstractResource {
     /**
      * @return Request being handled.
      */
-    protected final Request getRequest() {
+    protected Request getRequest() {
         return request;
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/HandlerServlet.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/HandlerServlet.java
@@ -76,7 +76,8 @@ public class HandlerServlet extends HttpServlet {
             }
 
             resource = route.getResource().getDeclaredConstructor().newInstance();
-            resource.setRequest(new Request(request, route.getPathArguments()));
+            Request iiifrequest = route.getRequest().getDeclaredConstructor(HttpServletRequest.class, List.class).newInstance(request, route.getPathArguments());
+            resource.setRequest(iiifrequest);
             resource.setResponse(response);
             resource.doInit();
 

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/IIIFRequest.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/IIIFRequest.java
@@ -1,0 +1,82 @@
+package edu.illinois.library.cantaloupe.resource;
+import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.image.Identifier;
+import edu.illinois.library.cantaloupe.image.MetaIdentifier;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+public class IIIFRequest extends Request {
+
+    /**
+     * Cached by {@link #getIdentifier()}.
+     */
+    private Identifier identifier;
+   
+    public IIIFRequest(HttpServletRequest request, List<String> pathArguments) {
+        super(request, pathArguments);
+    }
+
+        /**
+     * <p>Returns the decoded identifier path component of the URI. (This may
+     * not be the identifier that the client supplies or sees; for that, use
+     * {@link #getPublicIdentifier()}.)</p>
+     *
+     * <p>N.B.: Depending on the image request endpoint API, The return value
+     * may include "meta-information" that is not part of the identifier but is
+     * encoded along with it. In that case, it is not safe to consume via this
+     * method, and {@link #getMetaIdentifier()} should be used instead.</p>
+     *
+     * @return Identifier, or {@code null} if the URI does not have an
+     *         identifier path component.
+     * @see #getMetaIdentifier()
+     * @see #getPublicIdentifier()
+     */
+    public Identifier getIdentifier() {
+        if (identifier == null) {
+            String pathComponent = getIdentifierPathComponent();
+            if (pathComponent != null) {
+                identifier = Identifier.fromURIPathComponent(pathComponent);
+            }
+        }
+        return identifier;
+    }
+
+    public static final String PUBLIC_IDENTIFIER_HEADER = "X-Forwarded-ID";
+
+
+    /**
+     * <p>Returns the identifier that the client sees. This will be the value
+     * of the {@link #PUBLIC_IDENTIFIER_HEADER} header, if available, or else
+     * the {@code identifier} URI path component.</p>
+     *
+     * <p>The result is not decoded, as the encoding may be influenced by
+     * {@link Key#SLASH_SUBSTITUTE}, for example.</p>
+     *
+     * @see #getIdentifier()
+     */
+    public String getPublicIdentifier() {
+        return getHeaders().getFirstValue(
+                PUBLIC_IDENTIFIER_HEADER,
+                getIdentifierPathComponent());
+    }
+
+
+    /**
+     * <p>Returns the first {@link #getPathArguments() path argument}. (Most
+     * resources have an identifier as the first path argument, so this will
+     * work for them, but if not, an override will be necessary.)</p>
+     *
+     * <p>The result is not decoded and may be a {@link MetaIdentifier
+     * meta-identifier}. As such, it is not usable without additional
+     * processing.</p>
+     *
+     * @return Identifier, or {@code null} if no path arguments are
+     *         available.
+     */
+    public String getIdentifierPathComponent() {
+        List<String> args = getPathArguments();
+        return (!args.isEmpty()) ? args.get(0) : null;
+    }
+
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/Request.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/Request.java
@@ -6,7 +6,6 @@ import edu.illinois.library.cantaloupe.delegate.DelegateProxy;
 import edu.illinois.library.cantaloupe.http.Headers;
 import edu.illinois.library.cantaloupe.http.Query;
 import edu.illinois.library.cantaloupe.http.Reference;
-import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,17 +21,13 @@ import java.util.Set;
 /**
  * Wraps an {@link HttpServletRequest}, adding some convenience methods.
  */
-public final class Request {
+public class Request {
 
     private HttpServletRequest wrappedRequest;
     private Headers headers;
     private Reference reference;
     private List<String> pathArguments;
 
-    /**
-     * Cached by {@link #getIdentifier()}.
-     */
-    private Identifier identifier;
 
     private static final Logger LOGGER =
             LoggerFactory.getLogger(Request.class);
@@ -64,68 +59,6 @@ public final class Request {
      */
     public final List<String> getPathArguments() {
         return pathArguments;
-    }
-
-    /**
-     * <p>Returns the decoded identifier path component of the URI. (This may
-     * not be the identifier that the client supplies or sees; for that, use
-     * {@link #getPublicIdentifier()}.)</p>
-     *
-     * <p>N.B.: Depending on the image request endpoint API, The return value
-     * may include "meta-information" that is not part of the identifier but is
-     * encoded along with it. In that case, it is not safe to consume via this
-     * method, and {@link #getMetaIdentifier()} should be used instead.</p>
-     *
-     * @return Identifier, or {@code null} if the URI does not have an
-     *         identifier path component.
-     * @see #getMetaIdentifier()
-     * @see #getPublicIdentifier()
-     */
-    public Identifier getIdentifier() {
-        if (identifier == null) {
-            String pathComponent = getIdentifierPathComponent();
-            if (pathComponent != null) {
-                identifier = Identifier.fromURIPathComponent(pathComponent);
-            }
-        }
-        return identifier;
-    }
-
-    public static final String PUBLIC_IDENTIFIER_HEADER = "X-Forwarded-ID";
-
-
-    /**
-     * <p>Returns the identifier that the client sees. This will be the value
-     * of the {@link #PUBLIC_IDENTIFIER_HEADER} header, if available, or else
-     * the {@code identifier} URI path component.</p>
-     *
-     * <p>The result is not decoded, as the encoding may be influenced by
-     * {@link Key#SLASH_SUBSTITUTE}, for example.</p>
-     *
-     * @see #getIdentifier()
-     */
-    public String getPublicIdentifier() {
-        return getHeaders().getFirstValue(
-                PUBLIC_IDENTIFIER_HEADER,
-                getIdentifierPathComponent());
-    }
-
-
-    /**
-     * <p>Returns the first {@link #getPathArguments() path argument}. (Most
-     * resources have an identifier as the first path argument, so this will
-     * work for them, but if not, an override will be necessary.)</p>
-     *
-     * <p>The result is not decoded and may be a {@link MetaIdentifier
-     * meta-identifier}. As such, it is not usable without additional
-     * processing.</p>
-     *
-     * @return Identifier, or {@code null} if no path arguments are
-     *         available.
-     */
-    public String getIdentifierPathComponent() {
-        List<String> args = getPathArguments();
-        return (!args.isEmpty()) ? args.get(0) : null;
     }
 
     public Headers getHeaders() {

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/Route.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/Route.java
@@ -30,72 +30,92 @@ public final class Route {
      * N.B.: the {@link LinkedHashMap} preserves order as each mapping will be
      * checked sequentially and the first match used.
      */
-    private static final Map<Pattern,Class<? extends AbstractResource>> MAPPINGS =
+    private static final Map<Pattern,RouteEntry> MAPPINGS =
             new LinkedHashMap<>();
 
+    private static class RouteEntry {
+        Class<? extends AbstractResource> resource;
+        Class<? extends Request> request;
+
+        RouteEntry(Class<? extends AbstractResource> resource, Class<? extends Request> request) {
+            this.request = request;
+            this.resource = resource;
+        }
+
+        public Class<? extends AbstractResource> getResourceClass() {
+            return resource;
+        }
+
+        public Class<? extends Request> getRequestClass() {
+            return request;
+        }
+    }
     private Class<? extends AbstractResource> resource;
+    private Class<? extends Request> request;
+
     private final List<String> pathArguments = new ArrayList<>();
 
     static {
+
         // N.B.: Regex groups are used to extract the URI path arguments.
         MAPPINGS.put(Pattern.compile("\\A\\z"),
-                LandingResource.class);
+                new RouteEntry(LandingResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^/$"),
-                LandingResource.class);
+                new RouteEntry(LandingResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("/$"),
-                TrailingSlashRemovingResource.class);
+                new RouteEntry(TrailingSlashRemovingResource.class, Request.class));
 
         // IIIF Image API v3 routes
         MAPPINGS.put(Pattern.compile("^" + IIIF_3_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v3.LandingResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_3_PATH + "/([^/]+)/info\\.json$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v3.InformationResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_3_PATH + "/([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v3.IdentifierResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_3_PATH + "/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)\\.([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v3.ImageResource.class, IIIFRequest.class));
 
         // IIIF Image API v2 routes
         MAPPINGS.put(Pattern.compile("^" + IIIF_2_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v2.LandingResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_2_PATH + "/([^/]+)/info\\.json$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v2.InformationResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_2_PATH + "/([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v2.IdentifierResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_2_PATH + "/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)\\.([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v2.ImageResource.class, IIIFRequest.class));
 
         // IIIF Image API v1 routes
         MAPPINGS.put(Pattern.compile("^" + IIIF_1_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v1.LandingResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_1_PATH + "/([^/]+)/info\\.json$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v1.InformationResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_1_PATH + "/([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v1.IdentifierResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_1_PATH + "/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/.]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResource.class, IIIFRequest.class));
         MAPPINGS.put(Pattern.compile("^" + IIIF_1_PATH + "/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/.]+)\\.([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.iiif.v1.ImageResource.class, IIIFRequest.class));
 
         // Control Panel routes
         MAPPINGS.put(Pattern.compile("^" + ADMIN_CONFIG_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.admin.ConfigurationResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.admin.ConfigurationResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + ADMIN_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.admin.AdminResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.admin.AdminResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + ADMIN_STATUS_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.admin.StatusResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.admin.StatusResource.class, Request.class));
 
         // API routes
         MAPPINGS.put(Pattern.compile("^" + CONFIGURATION_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.api.ConfigurationResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.api.ConfigurationResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + HEALTH_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.health.HealthResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.health.HealthResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + STATUS_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.api.StatusResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.api.StatusResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + TASKS_PATH + "$"),
-                edu.illinois.library.cantaloupe.resource.api.TasksResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.api.TasksResource.class, Request.class));
         MAPPINGS.put(Pattern.compile("^" + TASKS_PATH + "/([^/]+)$"),
-                edu.illinois.library.cantaloupe.resource.api.TaskResource.class);
+                new RouteEntry(edu.illinois.library.cantaloupe.resource.api.TaskResource.class, Request.class));
     }
 
     /**
@@ -108,8 +128,8 @@ public final class Route {
             final Pattern pattern = entry.getKey();
             final Matcher matcher = pattern.matcher(path);
             if (matcher.find()) {
-                final Route route = new Route();
-                route.setResource(entry.getValue());
+                RouteEntry routeEntry = entry.getValue();
+                final Route route = new Route(routeEntry.getResourceClass(), routeEntry.getRequestClass());
                 for (int i = 1; i <= matcher.groupCount(); i++) {
                     route.getPathArguments().add(matcher.group(i));
                 }
@@ -117,6 +137,11 @@ public final class Route {
             }
         }
         return null;
+    }
+
+    Route(Class<? extends AbstractResource> resource, Class<? extends Request> request) {
+        this.resource = resource;
+        this.request = request;
     }
 
     /**
@@ -137,8 +162,10 @@ public final class Route {
         return resource;
     }
 
-    void setResource(Class<? extends AbstractResource> resource) {
-        this.resource = resource;
+    /**
+     * @return Request the users intent
+     */
+    Class<? extends Request> getRequest() {
+        return request;
     }
-
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/IIIFResource.java
@@ -9,6 +9,7 @@ import edu.illinois.library.cantaloupe.http.Reference;
 import edu.illinois.library.cantaloupe.http.Status;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.resource.AbstractResource;
+import edu.illinois.library.cantaloupe.resource.IIIFRequest;
 import edu.illinois.library.cantaloupe.resource.RequestContextDecorator;
 import edu.illinois.library.cantaloupe.resource.ResourceException;
 import edu.illinois.library.cantaloupe.resource.StringRepresentation;
@@ -36,6 +37,11 @@ public abstract class IIIFResource extends AbstractResource {
                             getRequest().getPublicReference(),
                             getRequest());
         addHeaders();
+    }
+
+    @Override
+    protected IIIFRequest getRequest() {
+        return (IIIFRequest) super.getRequest();
     }
 
     private void addHeaders() {

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/RequestTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/RequestTest.java
@@ -73,11 +73,9 @@ class RequestTest extends BaseTest {
         final String baseURI = "http://example.net/base";
         Configuration.getInstance().setProperty(Key.BASE_URI, baseURI);
 
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-        servletRequest.setContextPath("/base");
-        servletRequest.setRequestURL("http://example.org/base/llamas");
+        sr.setContextPath("/base");
+        sr.setRequestURL("http://example.org/base/llamas");
 
-        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(baseURI + "/llamas", ref.toString());
     }
@@ -91,12 +89,9 @@ class RequestTest extends BaseTest {
      */
     @Test
     void testGetPublicReferenceUsingXForwardedHeaders() {
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        sr.setContextPath("");
+        sr.setRequestURL("http://bogus/cats");
 
-        servletRequest.setContextPath("");
-        servletRequest.setRequestURL("http://bogus/cats");
-
-        instance = new Request(servletRequest, Collections.emptyList());
         Headers headers = instance.getHeaders();
         headers.set("X-Forwarded-Proto", "HTTP");
         headers.set("X-Forwarded-Host", "example.org");
@@ -114,11 +109,9 @@ class RequestTest extends BaseTest {
     @Test
     void testGetPublicReferenceFallsBackToHTTPRequest() {
         String resourceURI = "http://example.net/cats/dogs";
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-        servletRequest.setContextPath("/cats");
-        servletRequest.setRequestURL(resourceURI);
+        sr.setContextPath("/cats");
+        sr.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(resourceURI, ref.toString());
     }
@@ -130,12 +123,10 @@ class RequestTest extends BaseTest {
     @Test
     void testGetPublicReferenceFallsBackToHTTPSRequest() {
         String resourceURI = "https://example.net/cats/dogs";
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
 
-        servletRequest.setContextPath("/cats");
-        servletRequest.setRequestURL(resourceURI);
+        sr.setContextPath("/cats");
+        sr.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(resourceURI, ref.toString());
     }
@@ -145,11 +136,9 @@ class RequestTest extends BaseTest {
         String resourceURI = "https://example.net/cats/dogs?arg=value";
         String expected = "https://example.net/cats/dogs";
 
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-        servletRequest.setContextPath("/cats");
-        servletRequest.setRequestURL(resourceURI);
+        sr.setContextPath("/cats");
+        sr.setRequestURL(resourceURI);
 
-        instance = new Request(servletRequest, Collections.emptyList());
         Reference ref = instance.getPublicReference();
         assertEquals(expected, ref.toString());
     }

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/InformationResourceTester.java
@@ -10,7 +10,7 @@ import edu.illinois.library.cantaloupe.http.ResourceException;
 import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.test.TestUtil;
-import edu.illinois.library.cantaloupe.resource.Request;
+import edu.illinois.library.cantaloupe.resource.IIIFRequest;
 
 import java.io.File;
 import java.net.URI;
@@ -400,7 +400,7 @@ public class InformationResourceTester extends ImageAPIResourceTester {
     public void testRedirectToInfoJSONWithDifferentPublicIdentifier(URI uri)
             throws Exception {
         Client client = newClient(uri);
-        client.getHeaders().set(Request.PUBLIC_IDENTIFIER_HEADER, "foxes");
+        client.getHeaders().set(IIIFRequest.PUBLIC_IDENTIFIER_HEADER, "foxes");
         try {
             Response response = client.send();
             assertEquals(303, response.getStatus());

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v1/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.Request;
+import edu.illinois.library.cantaloupe.resource.IIIFRequest;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -511,7 +511,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                IIIFRequest.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.Request;
+import edu.illinois.library.cantaloupe.resource.IIIFRequest;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -533,7 +533,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                IIIFRequest.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v3/InformationResourceTest.java
@@ -11,7 +11,7 @@ import edu.illinois.library.cantaloupe.http.Response;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.image.MetaIdentifier;
 import edu.illinois.library.cantaloupe.image.StandardMetaIdentifierTransformer;
-import edu.illinois.library.cantaloupe.resource.Request;
+import edu.illinois.library.cantaloupe.resource.IIIFRequest;
 import edu.illinois.library.cantaloupe.resource.ResourceTest;
 import edu.illinois.library.cantaloupe.resource.Route;
 import edu.illinois.library.cantaloupe.resource.iiif.InformationResourceTester;
@@ -510,7 +510,7 @@ public class InformationResourceTest extends ResourceTest {
         client.getHeaders().set("X-Forwarded-Port", "8080");
         client.getHeaders().set("X-Forwarded-Path", "/cats");
         client.getHeaders().set(
-                Request.PUBLIC_IDENTIFIER_HEADER, "originalID");
+                IIIFRequest.PUBLIC_IDENTIFIER_HEADER, "originalID");
         Response response = client.send();
 
         String json = response.getBodyAsString();


### PR DESCRIPTION
This will support things only in IIIFRequests (like identifiers).  This also extracts a RouteEntry that matches a route to the resource being served.  Certain routes (Images & Info) get IIIFRequests, while other routes get plain Requests. 