### PR TITLE
Update dependencies with published CVE fixes (clears all Trivy findings, incl. 1 critical)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,15 +17,44 @@
         <maven.compile.target>21</maven.compile.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.10</jetty.version>
         <aws-sdk.version>2.42.37</aws-sdk.version>
         <jackson.version>2.21.5</jackson.version>
-        <jruby.version>10.1.0.0</jruby.version>
+        <jruby.version>10.1.1.0</jruby.version>
         <surefire.version>3.5.3</surefire.version>
         <seleniumhq.version>4.43.0</seleniumhq.version>
-        <logback.version>1.5.33</logback.version> <!-- slf4j depends on specific versions of logback. -->
+        <logback.version>1.5.34</logback.version> <!-- slf4j depends on specific versions of logback. -->
         <slf4j.version>2.0.18</slf4j.version>
     </properties>
+    <!-- Pin transitive dependencies with published CVE fixes that the
+         direct dependency tree has not yet picked up. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.136.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.28.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>4.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.iq80.snappy</groupId>
+                <artifactId>snappy</artifactId>
+                <version>0.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,17 @@
         <slf4j.version>2.0.18</slf4j.version>
     </properties>
     <!-- Pin transitive dependencies with published CVE fixes that the
-         direct dependency tree has not yet picked up. -->
+         direct dependency tree has not yet picked up. Each pin notes the
+         direct dependency that pulls it in and the condition under which
+         the pin can be deleted. To re-check at any time: remove this block
+         and run `mvn dependency:tree -Dincludes=io.netty:*,org.apache.commons:commons-compress,org.codehaus.plexus:plexus-utils,org.iq80.snappy:snappy`;
+         if the natively resolved versions meet or exceed the pins, the
+         block is no longer needed. -->
     <dependencyManagement>
         <dependencies>
+            <!-- via lettuce-core 6.2.7.RELEASE (resolves netty 4.1.101) and
+                 awssdk netty-nio-client; remove once lettuce is upgraded to a
+                 release shipping netty >= 4.1.136. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
@@ -37,16 +45,24 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- via jena-core 4.10.0 -> jena-base (resolves 1.24.0); remove
+                 once Jena is upgraded past 4.10 (Jena 5.x ships >= 1.26;
+                 >= 1.28 covers the outstanding CVEs). -->
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.28.0</version>
             </dependency>
+            <!-- via maven-assembly-plugin 3.7.1, declared as a project
+                 dependency (resolves 4.0.0); remove once that plugin is
+                 upgraded to a version shipping plexus-utils >= 4.0.3. -->
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>4.0.3</version>
             </dependency>
+            <!-- via maven-assembly-plugin 3.7.1 -> plexus-archiver 4.9.2
+                 (resolves 0.4); remove once that chain ships snappy >= 0.5. -->
             <dependency>
                 <groupId>org.iq80.snappy</groupId>
                 <artifactId>snappy</artifactId>


### PR DESCRIPTION
## Motivation

We build Cantaloupe from `develop` (at 377942b) in a CI pipeline that runs [Trivy](https://trivy.dev) vulnerability scanning over the built image on every commit. Findings against the bundled Java dependencies (`--ignore-unfixed`, i.e. only vulnerabilities with a published fix):

- **`develop` as-is: 41 CVEs — 1 critical, 15 high**
- (for reference, the 5.0.7 release: 67 CVEs — 2 critical)
- **with this PR: 0**

## Changes

All version-only: three property bumps plus a `dependencyManagement` section pinning vulnerable transitives the direct tree hasn't picked up yet.

| Dependency | From | To | Notes |
|---|---|---|---|
| logback | 1.5.33 | 1.5.34 | CVE-2026-10532 |
| Jetty | 12.1.7 | 12.1.10 | security releases (jetty-security, jetty-server, jetty-http fixes) |
| JRuby | 10.1.0.0 | 10.1.1.0 | see below — this one is the critical |
| netty-bom (pin) | 4.1.101–132 (transitive) | 4.1.136.Final | multiple 2025/2026 codec / codec-http CVEs incl. request smuggling |
| commons-compress (pin) | 1.24–1.26 | 1.28.0 | several archive-handling CVEs |
| plexus-utils (pin) | 4.0.0 | 4.0.3 | CVE fix |
| snappy (pin) | 0.4 | 0.5 | CVE-2024-36124 |

### The JRuby subtlety (worth knowing even if you take nothing else)

The **critical** finding (CVE-2025-14813, BouncyCastle `bcprov`) is **not in the Maven dependency tree** — `mvn dependency:tree -Dincludes=org.bouncycastle` returns nothing. BouncyCastle is **shaded inside `jruby-complete`**, so no `dependencyManagement` pin can reach it. The only fix is the JRuby bump: 10.1.1.0 (2026-07-22) ships jruby-openssl 0.16.2 with the BouncyCastle CVE fixes.

## Testing

- `mvn package` builds cleanly (Temurin 21 toolchain, tests deliberately left to your CI)
- Runtime smoke-tested on Temurin 25: startup, `/health` GREEN, IIIF v2/v3 information responses OK
- Trivy scan of the resulting image: zero findings at all severities

Happy to adjust anything to project conventions. And for what it's worth from a downstream consumer: `develop` is in genuinely good shape — we'd love to see it cut as a release.

🤖 Prepared with [Claude Code](https://claude.com/claude-code) on behalf of the repo owner.