### PR TITLE
Update jruby to 10.1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <jetty.version>12.1.7</jetty.version>
         <aws-sdk.version>2.42.37</aws-sdk.version>
         <jackson.version>2.21.5</jackson.version>
-        <jruby.version>10.1.0.0</jruby.version>
+        <jruby.version>10.1.1.0</jruby.version>
         <surefire.version>3.5.3</surefire.version>
         <seleniumhq.version>4.43.0</seleniumhq.version>
         <logback.version>1.5.34</logback.version> <!-- slf4j depends on specific versions of logback. -->


### PR DESCRIPTION
See https://www.jruby.org/2026/07/22/jruby-10-1-1-0.html

* jruby-openssl updated to 0.16.2 with several CVE fixes from BouncyCastle. #9386, #9504, #9539
* erb updated to 6.0.1.1 to address CVE-2026-41316. #9388